### PR TITLE
fix(komf): serve gzip-only Komelia webui assets via gateway rewrite

### DIFF
--- a/kubernetes/apps/main/media/komf/app/helmrelease.yaml
+++ b/kubernetes/apps/main/media/komf/app/helmrelease.yaml
@@ -45,20 +45,8 @@ spec:
         ports:
           http:
             port: &port 8085
-    route:
-      app:
-        annotations:
-          gethomepage.dev/enabled: "true"
-          gethomepage.dev/group: Books
-          gethomepage.dev/name: Komf
-          gethomepage.dev/icon: komga.png
-          gethomepage.dev/description: Komga Metadata Analyser
-          external-dns.alpha.kubernetes.io/target: internal.${SECRET_DOMAIN}
-        hostnames:
-          - "{{ .Release.Name }}.${SECRET_DOMAIN}"
-        parentRefs:
-          - name: envoy-internal
-            namespace: network
+    # HTTPRoute is defined in ./httproute.yaml because the Komelia webui assets
+    # need a gzip-rewrite workaround that app-template's route block can't express.
     persistence:
       config:
         enabled: true

--- a/kubernetes/apps/main/media/komf/app/httproute.yaml
+++ b/kubernetes/apps/main/media/komf/app/httproute.yaml
@@ -1,0 +1,68 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.networking.k8s.io/httproute_v1.json
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: komf
+  annotations:
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Books
+    gethomepage.dev/name: Komf
+    gethomepage.dev/icon: komga.png
+    gethomepage.dev/description: Komga Metadata Analyser
+    external-dns.alpha.kubernetes.io/target: internal.${SECRET_DOMAIN}
+spec:
+  hostnames:
+    - "komf.${SECRET_DOMAIN}"
+  parentRefs:
+    - name: envoy-internal
+      namespace: network
+  rules:
+    # Komelia webui ships its JS/wasm gzip-only (komelia-app.js.gz, *.wasm.gz),
+    # and Ktor 3.3.x won't serve them under their bare names. Rewrite to the .gz
+    # asset and tag the response so the browser decompresses and uses it.
+    - matches:
+        - path:
+            type: RegularExpression
+            value: .*\.js$
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: gateway.envoyproxy.io
+            kind: HTTPRouteFilter
+            name: komf-gz-rewrite
+        - type: ResponseHeaderModifier
+          responseHeaderModifier:
+            set:
+              - name: Content-Encoding
+                value: gzip
+              - name: Content-Type
+                value: text/javascript
+      backendRefs:
+        - name: komf
+          port: 8085
+    - matches:
+        - path:
+            type: RegularExpression
+            value: .*\.wasm$
+      filters:
+        - type: ExtensionRef
+          extensionRef:
+            group: gateway.envoyproxy.io
+            kind: HTTPRouteFilter
+            name: komf-gz-rewrite
+        - type: ResponseHeaderModifier
+          responseHeaderModifier:
+            set:
+              - name: Content-Encoding
+                value: gzip
+              - name: Content-Type
+                value: application/wasm
+      backendRefs:
+        - name: komf
+          port: 8085
+    # Everything else (index.html, /api, the .gz assets by their real name) is
+    # served unchanged.
+    - backendRefs:
+        - name: komf
+          port: 8085

--- a/kubernetes/apps/main/media/komf/app/httproutefilter.yaml
+++ b/kubernetes/apps/main/media/komf/app/httproutefilter.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.envoyproxy.io/httproutefilter_v1alpha1.json
+# Rewrites requests for the gzip-only Komelia webui assets to their stored
+# ".gz" name, e.g. /komelia-app.js -> /komelia-app.js.gz, /<hash>.wasm ->
+# /<hash>.wasm.gz. komf bundles these assets pre-compressed only, and Ktor
+# 3.3.x's preCompressed handler fails to serve them under their bare names from
+# the jar, so the browser otherwise receives index.html and renders blank.
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: HTTPRouteFilter
+metadata:
+  name: komf-gz-rewrite
+spec:
+  urlRewrite:
+    path:
+      type: ReplaceRegexMatch
+      replaceRegexMatch:
+        pattern: '^/(.*)\.(js|wasm)$'
+        substitution: '/\1.\2.gz'

--- a/kubernetes/apps/main/media/komf/app/kustomization.yaml
+++ b/kubernetes/apps/main/media/komf/app/kustomization.yaml
@@ -5,6 +5,8 @@ kind: Kustomization
 resources:
   - ./externalsecret.yaml
   - ./helmrelease.yaml
+  - ./httproute.yaml
+  - ./httproutefilter.yaml
 configMapGenerator:
   - name: komf-configmap
     files:


### PR DESCRIPTION
## Problem

The bundled Komelia web UI at `https://komf.wlab.ovh` renders a blank canvas. komf is **not** broken upstream and the image is fine — the backend `/api/*` all return 200.

Root cause (confirmed by unpacking the published `sndxr/komf` jars): komf ships the webui assets **gzip-only** (`komelia/komelia-app.js.gz`, `*.wasm.gz`) and relies on Ktor `preCompressed(GZIP)` to serve them under their bare names. **Ktor 3.3.x** (komf ≥ 1.6.1) regressed and no longer resolves the `.gz`-only classpath resources from the jar, so a request for `komelia-app.js` falls through to `default("index.html")` → the browser executes HTML as JS → blank. The assets are present and individually fetchable at their `.gz` names.

## Fix

Replace the app-template `route:` block (can't express `ExtensionRef` filters) with a raw `HTTPRoute` + Envoy Gateway `HTTPRouteFilter`:

- `httproutefilter.yaml` — regex rewrite `^/(.*)\.(js|wasm)$` → `/\1.\2.gz`
- `httproute.yaml` — `*.js` / `*.wasm` rules apply the rewrite + set `Content-Encoding: gzip` and correct `Content-Type` (`text/javascript` / `application/wasm`); catch-all rule serves index.html, `/api` and real `.gz` names unchanged. Homepage + external-dns annotations moved onto the route. komf does not double-gzip, so Accept-Encoding needs no handling.

## Verify after reconcile

```bash
curl -s --compressed -o /dev/null -w "%{http_code} %{content_type} %{size_download}\n" https://komf.wlab.ovh/komelia-app.js   # expect text/javascript
curl -s --compressed -o /dev/null -w "%{http_code} %{content_type}\n" https://komf.wlab.ovh/8bc1b48ee28fd6b51bb9.wasm        # expect application/wasm
```

## Notes / follow-up

- This is a workaround for an upstream komf/Ktor bug; remove it (restore the app-template `route:`) once komf serves precompressed classpath resources again.
- komf's Komelia submodule is pinned ~v0.16.x (2025-07-23) while upstream Komelia is 0.18.5 — unrelated to this bug, but a custom image / fork would be the path if we want the newer Komelia.
- Reader-only assets (`composeResources/*.html.gz`) are not rewritten; add `.html` handling the same way if the in-browser reader is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)