### PR TITLE
feat(container)!: update reitti to 4.0.5

### DIFF
--- a/kubernetes/apps/main/default/reitti/app/externalsecret.yaml
+++ b/kubernetes/apps/main/default/reitti/app/externalsecret.yaml
@@ -11,9 +11,6 @@ spec:
   refreshInterval: 15m
   target:
     name: reitti-secret
-    template:
-      data:
-        CUSTOM_TILES_SERVICE: "{{ .CUSTOM_TILES_SERVICE }}"
   dataFrom:
     - extract:
         key: reitti

--- a/kubernetes/apps/main/default/reitti/app/helmrelease.yaml
+++ b/kubernetes/apps/main/default/reitti/app/helmrelease.yaml
@@ -18,7 +18,7 @@ spec:
           app: &reitti
             image:
               repository: dedicatedcode/reitti
-              tag: 3.4.1
+              tag: 4.0.5
             env:
               POSTGIS_DB: *app
               POSTGIS_PORT: 5432
@@ -29,15 +29,9 @@ spec:
                   secretKeyRef:
                     name: postgres-reitti-app
                     key: password
-              RABBITMQ_HOST: ""
-              RABBITMQ_PORT: 5672
-              RABBITMQ_USER: "reitti"
-              RABBITMQ_PASSWORD: "reitti"
               REDIS_HOST: "reitti-dragonfly.default.svc.cluster.local"
               REDIS_PORT: 6379
               # PHOTON_BASE_URL: http://photon.default:2322
-              # CUSTOM_TILES_ATTRIBUTION: '© MapTiler © OpenStreetMap contributors'
-              TILES_CACHE: ""
             envFrom:
               - secretRef:
                   name: reitti-secret
@@ -48,21 +42,6 @@ spec:
               limits:
                 memory: "3Gi"
                 cpu: "2000m"
-          # Move to standalone deployment someday I guess
-          rabbitmq:
-            image:
-              repository: rabbitmq
-              tag: 3-management-alpine
-            env:
-              RABBITMQ_DEFAULT_USER: reitti
-              RABBITMQ_DEFAULT_PASS: reitti
-            resources:
-              requests:
-                memory: "1Gi"
-                cpu: "250m"
-              limits:
-                memory: "3Gi"
-                cpu: "1500m"
     service:
       app:
         controller: *app


### PR DESCRIPTION
Migrate per v3->v4 upgrade guide: drop RabbitMQ (removed in v4), remove unsupported custom tiles config, and drop unused tile cache. Photon migrates to the web UI automatically; Paikka is the new default geocoder.