### PR TITLE
feat(reitti)!: upgrade to 4.0.5 + bootstrap DB fresh

### DIFF
--- a/kubernetes/apps/main/default/reitti/ks.yaml
+++ b/kubernetes/apps/main/default/reitti/ks.yaml
@@ -12,7 +12,7 @@ spec:
       app.kubernetes.io/name: *app
   components:
     - ../../../../../components/dragonfly
-    - ../../../../../components/cnpg/restore
+    - ../../../../../components/cnpg/initdb
   dependsOn:
     - name: plugin-barman-cloud
       namespace: database


### PR DESCRIPTION
## Reitti v4 upgrade + Postgres recovery

### v3 → v4 migration (per [upgrade guide](https://www.dedicatedcode.com/projects/reitti/4.0/upgrade/))
- Bump image `3.4.1` → `4.0.5`
- **Remove RabbitMQ** — no longer required in v4 (dropped the sidecar container + all `RABBITMQ_*` env)
- **Remove custom tiles** — `CUSTOM_TILES_SERVICE`/`CUSTOM_TILES_ATTRIBUTION` have no v4 equivalent (also dropped from the ExternalSecret template)
- Drop unused `TILES_CACHE`
- Photon auto-migrates to the web UI on first boot; Paikka is the new default geocoder (public instance — can be disabled in Settings → Geocoding for privacy)

### Postgres DB fix
The `postgres-reitti` data PVC was lost and the S3 barman backup is **incomplete** — the base backup requires WAL segments `0A→11` that were never archived, so every restore loops on `FATAL: WAL ends before end of online backup`. The data is unrecoverable and not needed, so switch `cnpg/restore` → `cnpg/initdb` to bring the DB up empty.

> [!IMPORTANT]
> After merge, the existing broken cluster + PVC must be deleted so Flux rebuilds it fresh:
> ```
> kubectl delete cluster.postgresql.cnpg.io postgres-reitti -n default
> kubectl delete pvc postgres-reitti-1 -n default
> flux -n default reconcile kustomization reitti
> ```
> Once the first daily backup lands, switch `initdb` → `restore` again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)