### PR TITLE
feat(reitti)!: upgrade to v5 (5.0.1) + PostGIS initdb component

### DIFF
--- a/kubernetes/apps/main/default/reitti/app/helmrelease.yaml
+++ b/kubernetes/apps/main/default/reitti/app/helmrelease.yaml
@@ -18,7 +18,7 @@ spec:
           app: &reitti
             image:
               repository: dedicatedcode/reitti
-              tag: 4.0.5
+              tag: 5.0.1
             env:
               POSTGIS_DB: *app
               POSTGIS_PORT: 5432

--- a/kubernetes/apps/main/default/reitti/ks.yaml
+++ b/kubernetes/apps/main/default/reitti/ks.yaml
@@ -13,6 +13,9 @@ spec:
   components:
     - ../../../../../components/dragonfly
     - ../../../../../components/cnpg/initdb
+    # reitti stores geometry columns; enable PostGIS on the fresh initdb DB so a
+    # rebuilt cluster self-heals (list after initdb so bootstrap.initdb exists).
+    - ../../../../../components/cnpg/extensions/postgis
   dependsOn:
     - name: plugin-barman-cloud
       namespace: database

--- a/kubernetes/components/cnpg/extensions/postgis/kustomization.yaml
+++ b/kubernetes/components/cnpg/extensions/postgis/kustomization.yaml
@@ -1,0 +1,18 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+# Enables PostGIS in the application database. Assumes the cluster runs the
+# CloudNativePG PostGIS image (CNPG_IMAGE=ghcr.io/cloudnative-pg/postgis) so the
+# extension binaries are present; this just runs CREATE EXTENSION at bootstrap.
+# Use alongside cnpg/initdb and list it AFTER initdb so bootstrap.initdb exists.
+patches:
+  - target:
+      group: postgresql.cnpg.io
+      version: v1
+      kind: Cluster
+    patch: |-
+      - op: add
+        path: /spec/bootstrap/initdb/postInitApplicationSQL
+        value:
+          - CREATE EXTENSION IF NOT EXISTS postgis;


### PR DESCRIPTION
## Reitti v4 → v5 upgrade + durable PostGIS

### 1. PostGIS extension component (`feat(cnpg)`)
After moving reitti's Postgres to `cnpg/initdb` (#3602), the fresh DB had no PostGIS extension, so Flyway failed with `type "geometry" does not exist`. I created it manually on the live cluster to unblock, but that wouldn't survive a rebuild.

This adds a reusable `components/cnpg/extensions/postgis` component (same pattern as `extensions/vchord`) that runs `CREATE EXTENSION IF NOT EXISTS postgis` at bootstrap, referenced from reitti's `ks.yaml` after `cnpg/initdb`. Verified via `kustomize build` that `postInitApplicationSQL` merges onto the Cluster.

### 2. v5 upgrade (`feat(container)!`)
Image `4.0.5` → `5.0.1`. v5 introduces **Devices** as a core concept:
- On startup, GPS points migrate from the legacy table to a default device, and an index is built on `api_token_usages`. The doc warns this can be slow — but our DB was just re-initialized empty, so it's instant (no `api_token_usages` cleanup needed).
- Existing API tokens auto-link to a default device.

### Post-merge verification (UI, per the v5 guide)
- **Map style**: all users reset to the dark "Reitti" style; re-select "Colored Reitti" under Settings → Map Styles if preferred.
- **API tokens**: Settings → API Tokens — confirm tokens have a Device attached (needed to *ingest* location data; OwnTracks/HA push).
- We don't run the optional `reitti-tile-cache` sidecar (never did). If tiles don't load on v5, we may need to add it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)