### PR TITLE
feat(security): add kanidm IdP alongside authentik

### DIFF
--- a/kubernetes/apps/main/security/kanidm/app/README.md
+++ b/kubernetes/apps/main/security/kanidm/app/README.md
@@ -1,0 +1,43 @@
+# Kanidm
+
+Lightweight OIDC + LDAP identity provider, deployed alongside Authentik during migration
+(parallel-then-remove). Served on `idm.${SECRET_DOMAIN}`.
+
+- Kanidm terminates TLS itself → dedicated cert (`certificate.yaml`) mounted in-pod, and a
+  `BackendTLSPolicy` makes envoy re-encrypt/validate to the 8443 backend.
+- `provision` (kanidm-provision) reconciles groups/OIDC clients from ConfigMaps labeled
+  `kanidm_config: "1"`, and writes generated client secrets back into the target namespace.
+
+## First-boot bootstrap (one-time, manual)
+
+The provisioning token can't exist before the DB does, so `provision` ships at `replicas: 0`.
+
+1. Merge this app; wait for the `kanidm` StatefulSet pod to be Running (`/status` probe green).
+2. Recover admin accounts:
+   ```sh
+   kubectl -n security exec -it sts/kanidm -c app -- kanidmd recover-account admin
+   kubectl -n security exec -it sts/kanidm -c app -- kanidmd recover-account idm_admin
+   ```
+3. With the kanidm CLI (login as `idm_admin`), create a service account + API token for provisioning:
+   ```sh
+   kanidm service-account create provision "Provisioning" --name idm_admin
+   kanidm service-account api-token generate provision provision --rw --name idm_admin
+   ```
+4. Store the printed token in Bitwarden Secrets Manager under key `kanidm`, field
+   `KANIDM_PROVISION_TOKEN` (the `externalsecret.yaml` maps it to secret `kanidm-provision-token`).
+5. Scale up provisioning: set `controllers.provision.replicas: 1` in `helmrelease.yaml`.
+
+## PR 2 (cutover, follow-up)
+
+- Uncomment `provisioning/oauth2.yaml` (+ its line in `kustomization.yaml`), fill romm's real OIDC
+  redirect URI, and enable romm's native OIDC (`OIDC_*` in `../../media/romm/app/externalsecret.yaml`).
+- Delete `../../media/romm/app/securitypolicy.yaml` (authentik forward-auth).
+- Remove the `authentik` app and its `./authentik/ks.yaml` entry from the security kustomization.
+
+## Verification
+
+```sh
+kubectl -n security get certificate idm-tls            # Ready=True
+kubectl -n security get sts kanidm                     # 1/1
+curl -sf https://idm.${SECRET_DOMAIN}/status           # 200 through the gateway (re-encrypt path)
+```

--- a/kubernetes/apps/main/security/kanidm/app/backendtlspolicy.yaml
+++ b/kubernetes/apps/main/security/kanidm/app/backendtlspolicy.yaml
@@ -1,0 +1,17 @@
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/gateway.networking.k8s.io/backendtlspolicy_v1.json
+# Kanidm serves HTTPS on 8443, so envoy must re-encrypt to it. The backend cert is
+# LE-signed for idm.${SECRET_DOMAIN}, so validate against the system CA bundle.
+apiVersion: gateway.networking.k8s.io/v1
+kind: BackendTLSPolicy
+metadata:
+  name: kanidm-upstream
+spec:
+  targetRefs:
+    - group: ""
+      kind: Service
+      name: kanidm
+      sectionName: http
+  validation:
+    wellKnownCACertificates: System
+    hostname: idm.${SECRET_DOMAIN}

--- a/kubernetes/apps/main/security/kanidm/app/certificate.yaml
+++ b/kubernetes/apps/main/security/kanidm/app/certificate.yaml
@@ -1,0 +1,22 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/datreeio/CRDs-catalog/main/cert-manager.io/certificate_v1.json
+# Dedicated per-host cert: kanidm terminates TLS itself, so it needs the key material
+# in-pod (the gateway's wildcard secret lives in the network namespace only).
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: idm
+spec:
+  secretName: idm-tls
+  dnsNames:
+    - idm.${SECRET_DOMAIN}
+  duration: 160h
+  issuerRef:
+    kind: ClusterIssuer
+    name: letsencrypt-production
+  privateKey:
+    algorithm: ECDSA
+    size: 256
+    rotationPolicy: Always
+  usages:
+    - digital signature

--- a/kubernetes/apps/main/security/kanidm/app/configmap.yaml
+++ b/kubernetes/apps/main/security/kanidm/app/configmap.yaml
@@ -1,0 +1,28 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kanidm-config
+  annotations:
+    reloader.stakater.com/match: "true"
+data:
+  server.toml: |-
+    version = "2"
+    domain = "idm.${SECRET_DOMAIN}"
+    origin = "https://idm.${SECRET_DOMAIN}"
+    bindaddress = "[::]:8443"
+    ldapbindaddress = "[::]:3636"
+    db_path = "/data/kanidm.db"
+    tls_chain = "/certs/tls.crt"
+    tls_key = "/certs/tls.key"
+    adminbindpath = "/var/run/kanidmd.sock"
+
+    [online_backup]
+    path = "/data/backups"
+    schedule = "3 */6 * * *"
+    versions = 14
+
+    # Trust X-Forwarded-For from the in-cluster pod CIDR (Cilium native routing) so
+    # audit logs and rate-limiting see real client IPs, not the envoy pod IP.
+    [http_client_address_info]
+    x-forward-for = ["10.42.0.0/16"]

--- a/kubernetes/apps/main/security/kanidm/app/externalsecret.yaml
+++ b/kubernetes/apps/main/security/kanidm/app/externalsecret.yaml
@@ -1,0 +1,20 @@
+# yaml-language-server: $schema=https://lds-schemas.pages.dev/external-secrets.io/externalsecret_v1beta1.json
+---
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: kanidm-provision-token
+spec:
+  secretStoreRef:
+    name: bitwarden-secrets-manager
+    kind: ClusterSecretStore
+  refreshInterval: 1m
+  target:
+    name: kanidm-provision-token
+    template:
+      data:
+        # Service-account API token minted during first-boot bootstrap (see README.md).
+        token: "{{ .KANIDM_PROVISION_TOKEN }}"
+  dataFrom:
+    - extract:
+        key: kanidm

--- a/kubernetes/apps/main/security/kanidm/app/helmrelease.yaml
+++ b/kubernetes/apps/main/security/kanidm/app/helmrelease.yaml
@@ -1,0 +1,198 @@
+---
+# yaml-language-server: $schema=https://raw.githubusercontent.com/bjw-s-labs/helm-charts/main/charts/other/app-template/schemas/helmrelease-helm-v2.schema.json
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: &app kanidm
+spec:
+  interval: 1h
+  chartRef:
+    kind: OCIRepository
+    name: app-template
+  values:
+    defaultPodOptions:
+      automountServiceAccountToken: true
+      # Critical IdP — protect from eviction under memory pressure.
+      priorityClassName: system-cluster-critical
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 2000
+        runAsGroup: 2000
+        fsGroup: 2000
+        fsGroupChangePolicy: OnRootMismatch
+    serviceAccount:
+      # Powerless SA for the internet-facing server pod; RBAC lives on `provision` only.
+      kanidm: {}
+      provision: {}
+    controllers:
+      kanidm:
+        type: statefulset
+        replicas: 1
+        serviceAccount:
+          identifier: kanidm
+        pod:
+          annotations:
+            reloader.stakater.com/auto: "true"
+        containers:
+          app:
+            image:
+              repository: docker.io/kanidm/server
+              tag: 1.10.4
+            env:
+              KANIDM_ADMIN_BIND_PATH: /var/run/kanidmd.sock
+              KANIDM_DOMAIN: idm.${SECRET_DOMAIN}
+              KANIDM_ORIGIN: https://idm.${SECRET_DOMAIN}
+              KANIDM_BINDADDRESS: "[::]:8443"
+              KANIDM_LDAPBINDADDRESS: "[::]:3636"
+              KANIDM_DB_PATH: /data/kanidm.db
+              KANIDM_TLS_CHAIN: /certs/tls.crt
+              KANIDM_TLS_KEY: /certs/tls.key
+            probes:
+              liveness: &probe
+                enabled: true
+                custom: true
+                spec:
+                  httpGet:
+                    path: /status
+                    port: &port 8443
+                    scheme: HTTPS
+                  initialDelaySeconds: 0
+                  periodSeconds: 10
+                  timeoutSeconds: 1
+                  failureThreshold: 3
+              readiness: *probe
+            resources:
+              requests:
+                cpu: 25m
+                memory: 128Mi
+              limits:
+                memory: 512Mi
+            securityContext:
+              allowPrivilegeEscalation: false
+              readOnlyRootFilesystem: true
+              capabilities:
+                drop:
+                  - ALL
+      provision:
+        # Bootstrap: kept at 0 until the provisioning token exists (see README.md).
+        # Flip to 1 once kanidm-provision-token is populated in Bitwarden.
+        replicas: 0
+        serviceAccount:
+          identifier: provision
+        containers:
+          app:
+            image:
+              repository: ghcr.io/m00nwtchr/kanidm-provision
+              tag: main@sha256:1271844f1db6c3b7656f8954595591ab2c968b005ac4420127343fcb6a7d190f
+            env:
+              KANIDM_INSTANCE: https://idm.${SECRET_DOMAIN}
+              KANIDM_NAMESPACE: security
+              KANIDM_TOKEN:
+                valueFrom:
+                  secretKeyRef:
+                    name: kanidm-provision-token
+                    key: token
+            resources:
+              requests:
+                cpu: 10m
+                memory: 64Mi
+              limits:
+                memory: 128Mi
+            securityContext:
+              capabilities:
+                drop:
+                  - ALL
+    persistence:
+      data:
+        accessMode: ReadWriteOnce
+        size: 2Gi
+        storageClass: ceph-block
+        advancedMounts:
+          kanidm:
+            app:
+              - path: /data
+                subPath: data
+      certs:
+        type: secret
+        name: idm-tls
+        defaultMode: 0400
+        advancedMounts:
+          kanidm:
+            app:
+              - path: /certs
+      server-config:
+        type: configMap
+        name: kanidm-config
+        advancedMounts:
+          kanidm:
+            app:
+              - path: /data/server.toml
+                subPath: server.toml
+                readOnly: true
+      var-run:
+        type: emptyDir
+        globalMounts:
+          - path: /var/run
+      icon-cache:
+        accessMode: ReadWriteOnce
+        size: 1Gi
+        suffix: icon-cache
+        storageClass: ceph-block
+        advancedMounts:
+          provision:
+            app:
+              - path: /data/icons
+    rbac:
+      roles:
+        kanidm-write-secret:
+          type: ClusterRole
+          rules:
+            - apiGroups:
+                - ""
+              resources:
+                - "secrets"
+              verbs:
+                - "create"
+                - "patch"
+        kanidm-read-cm:
+          type: ClusterRole
+          rules:
+            - apiGroups:
+                - ""
+              resources:
+                - "configmaps"
+              verbs:
+                - "get"
+                - "list"
+                - "watch"
+      bindings:
+        kanidm-write-secret:
+          type: ClusterRoleBinding
+          roleRef:
+            identifier: kanidm-write-secret
+          subjects:
+            - identifier: provision
+        kanidm-read-cm:
+          type: ClusterRoleBinding
+          roleRef:
+            identifier: kanidm-read-cm
+          subjects:
+            - identifier: provision
+    service:
+      app:
+        controller: kanidm
+        ports:
+          http:
+            port: *port
+          ldap:
+            port: 3636
+    route:
+      app:
+        annotations:
+          gatus.home-operations.com/endpoint: |-
+            group: security
+        hostnames:
+          - idm.${SECRET_DOMAIN}
+        parentRefs:
+          - name: envoy-external
+            namespace: network

--- a/kubernetes/apps/main/security/kanidm/app/kustomization.yaml
+++ b/kubernetes/apps/main/security/kanidm/app/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ./externalsecret.yaml
+  - ./certificate.yaml
+  - ./configmap.yaml
+  - ./helmrelease.yaml
+  - ./backendtlspolicy.yaml
+  - ./provisioning/groups.yaml
+  # - ./provisioning/oauth2.yaml  # PR 2: enable once romm OIDC client is defined

--- a/kubernetes/apps/main/security/kanidm/app/provisioning/groups.yaml
+++ b/kubernetes/apps/main/security/kanidm/app/provisioning/groups.yaml
@@ -1,0 +1,21 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kanidm-provision-groups
+  labels:
+    kanidm_config: "1"
+  annotations:
+    reloader.stakater.com/match: "true"
+data:
+  # Base group hierarchy. Members are added during bootstrap
+  # (`kanidm group add-members ...`) or declared here once usernames exist.
+  groups.json: |-
+    {
+      "groups": {
+        "users":  { "present": true, "members": [], "overwriteMembers": false },
+        "admins": { "present": true, "members": [], "overwriteMembers": false }
+      },
+      "persons": {},
+      "systems": { "oauth2": {} }
+    }

--- a/kubernetes/apps/main/security/kanidm/app/provisioning/oauth2.yaml
+++ b/kubernetes/apps/main/security/kanidm/app/provisioning/oauth2.yaml
@@ -1,0 +1,32 @@
+---
+# OAuth2 clients provisioned by kanidm-provision. Each ConfigMap targets one namespace;
+# the generated client secret is written back there as a k8s Secret (k8s.clientSecretKey).
+#
+# Scaffold for PR 2 (romm native OIDC — replaces the authentik forward-auth SecurityPolicy).
+# Kept commented until romm's OIDC redirect URI is wired and `provision` is scaled to 1.
+#
+# apiVersion: v1
+# kind: ConfigMap
+# metadata:
+#   name: kanidm-provision-oauth2-media
+#   labels:
+#     kanidm_config: "1"
+#   annotations:
+#     reloader.stakater.com/match: "true"
+# data:
+#   targetNamespace: media
+#   oauth2.json: |
+#     {
+#       "groups": {}, "persons": {}, "systems": { "oauth2": {
+#         "romm": {
+#           "present": true, "displayName": "RomM",
+#           "originUrl": "https://romm.${SECRET_DOMAIN}/api/oauth/openid",
+#           "originLanding": "https://romm.${SECRET_DOMAIN}/",
+#           "scopeMaps": { "users": ["openid", "email", "profile"] },
+#           "k8s": {
+#             "clientIdKey": "OIDC_CLIENT_ID",
+#             "clientSecretKey": "OIDC_CLIENT_SECRET",
+#             "imageUrl": "https://raw.githubusercontent.com/homarr-labs/dashboard-icons/main/svg/romm.svg"
+#           }
+#         }
+#       } } }

--- a/kubernetes/apps/main/security/kanidm/ks.yaml
+++ b/kubernetes/apps/main/security/kanidm/ks.yaml
@@ -1,0 +1,23 @@
+---
+# yaml-language-server: $schema=https://kube-schemas.pages.dev/kustomize.toolkit.fluxcd.io/kustomization_v1.json
+apiVersion: kustomize.toolkit.fluxcd.io/v1
+kind: Kustomization
+metadata:
+  name: &app kanidm
+spec:
+  targetNamespace: security
+  dependsOn:
+    - name: cert-manager
+      namespace: cert-manager
+  interval: 1h
+  path: ./kubernetes/apps/main/security/kanidm/app
+  postBuild:
+    substitute:
+      APP: *app
+      SUBDOMAIN: idm
+  prune: true
+  sourceRef:
+    kind: GitRepository
+    name: flux-system
+    namespace: flux-system
+  wait: false

--- a/kubernetes/apps/main/security/kustomization.yaml
+++ b/kubernetes/apps/main/security/kustomization.yaml
@@ -7,3 +7,4 @@ components:
   - ../../../components/common
 resources:
   - ./authentik/ks.yaml
+  - ./kanidm/ks.yaml


### PR DESCRIPTION
## Summary

Deploys **Kanidm** (OIDC + LDAP identity provider) on `idm.${SECRET_DOMAIN}` as a lighter-weight replacement for Authentik. Ported from [vrozaksen/home-ops](https://github.com/vrozaksen/home-ops/tree/main/kubernetes/platform/security/kanidm) and adapted to this repo's conventions.

This is **PR 1 of 2** — a parallel deploy. Authentik keeps running untouched. A follow-up PR handles the cutover.

### Why
Kanidm is a single Rust binary with an **embedded SQLite DB** — no CNPG Postgres, no Dragonfly Redis, no worker deployment. That's the simplification win over Authentik.

## What's here
- `kanidm` StatefulSet + `kanidm-provision` (declarative groups/OIDC clients from ConfigMaps labelled `kanidm_config: "1"`).
- Dedicated cert-manager `Certificate` (`idm-tls`) mounted in-pod — kanidm terminates TLS itself.
- `BackendTLSPolicy` (first in the repo, `gateway.networking.k8s.io/v1`) so envoy re-encrypts/validates to the 8443 HTTPS backend.
- `server.toml` ConfigMap (6h backups ×14, XFF trust scoped to pod CIDR `10.42.0.0/16`).
- Bitwarden ExternalSecret for the provision token; base `users`/`admins` groups; commented romm OIDC scaffold for PR 2.

### Adaptations from the reference
`idm.${SECRET_DOMAIN}` instead of a hardcoded domain · dropped `KANIDM_MAIL_RELAY` (no smtp-relay) and control-plane `nodeSelector`/`tolerations` (control-planes are schedulable here) · auto `ceph-block` PVC instead of `existingClaim` · Bitwarden instead of Infisical · skipped the CiliumNetworkPolicy/LDAPS-passthrough (no netpols anywhere in this repo).

## ⚠️ Manual steps after merge (see `app/README.md`)
1. **Bootstrap the provision token** (chicken-and-egg — kanidm can't mint it before its DB exists). `provision` ships at `replicas: 0`; run `kanidmd recover-account`, create a service-account API token, store it in Bitwarden under key `kanidm` / field `KANIDM_PROVISION_TOKEN`, then flip `provision` to `replicas: 1`.

## Follow-up (PR 2 — the cutover)
Kanidm has **no forward-auth outpost**, so romm (currently gated by a `SecurityPolicy` → authentik embedded outpost) moves to romm's **native OIDC**: uncomment the oauth2 scaffold with romm's real redirect URI, enable romm's `OIDC_*`, delete `romm/app/securitypolicy.yaml`, and remove authentik.

## Validation
`kustomize build` + `kubeconform -strict` pass on all 6 resources (with `${SECRET_DOMAIN}` substituted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)