### PR TITLE
chore(kanidm): enable provision controller

### DIFF
--- a/kubernetes/apps/main/security/kanidm/app/helmrelease.yaml
+++ b/kubernetes/apps/main/security/kanidm/app/helmrelease.yaml
@@ -74,9 +74,8 @@ spec:
                 drop:
                   - ALL
       provision:
-        # Bootstrap: kept at 0 until the provisioning token exists (see README.md).
-        # Flip to 1 once kanidm-provision-token is populated in Bitwarden.
-        replicas: 0
+        # Enabled — provisioning token bootstrapped into kanidm-provision-token (see README.md).
+        replicas: 1
         serviceAccount:
           identifier: provision
         containers:


### PR DESCRIPTION
Follow-up to #3605. The provisioning API token has been bootstrapped into the
`kanidm-provision-token` secret, so scale `kanidm-provision` from 0 → 1 to start
reconciling groups and OIDC clients declaratively.

Once merged, Flux will roll the `kanidm-provision` Deployment to 1 replica and it
will apply the base groups (`users`, `admins`) from `provisioning/groups.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)