### PR TITLE
feat(sso): wave 1 native OIDC — komga, open-webui, karakeep

### DIFF
--- a/kubernetes/apps/main/default/karakeep/app/helmrelease.yaml
+++ b/kubernetes/apps/main/default/karakeep/app/helmrelease.yaml
@@ -31,8 +31,11 @@ spec:
               CRAWLER_FULL_PAGE_ARCHIVE: true
               CRAWLER_FULL_PAGE_SCREENSHOT: true
               CRAWLER_VIDEO_DOWNLOAD: true
-              # OAuth setup
-              # OAUTH_PROVIDER_NAME: Authentik
+              # OAuth (Kanidm OIDC). Client id/secret arrive via envFrom kanidm-karakeep-oidc.
+              # NextAuth sends PKCE, so the kanidm client keeps PKCE required.
+              OAUTH_PROVIDER_NAME: Kanidm
+              OAUTH_WELLKNOWN_URL: "https://idm.${SECRET_DOMAIN}/oauth2/openid/karakeep/.well-known/openid-configuration"
+              OAUTH_SCOPE: "openid email profile"
               DISABLE_PASSWORD_AUTH: false
               DISABLE_SIGNUPS: true
               DISABLE_NEW_RELEASE_CHECK: true
@@ -41,6 +44,8 @@ spec:
             envFrom: &envFrom
               - secretRef:
                   name: karakeep-secret
+              - secretRef:
+                  name: kanidm-karakeep-oidc
             probes:
               liveness:
                 enabled: true

--- a/kubernetes/apps/main/llm/open-webui/app/helmrelease.yaml
+++ b/kubernetes/apps/main/llm/open-webui/app/helmrelease.yaml
@@ -45,9 +45,16 @@ spec:
                   secretKeyRef:
                     name: "postgres-{{ .Release.Name }}-app"
                     key: uri
-            # envFrom:
-            #   - secretRef:
-            #       name: "{{ .Release.Name }}-secret"
+              # OIDC via Kanidm. OAUTH_CLIENT_ID/SECRET arrive via envFrom kanidm-open-webui-oidc.
+              WEBUI_URL: "https://chat.${SECRET_DOMAIN}"
+              ENABLE_OAUTH_SIGNUP: "true"
+              OAUTH_PROVIDER_NAME: Kanidm
+              OAUTH_SCOPES: "openid email profile"
+              OPENID_PROVIDER_URL: "https://idm.${SECRET_DOMAIN}/oauth2/openid/open-webui/.well-known/openid-configuration"
+              OPENID_REDIRECT_URI: "https://chat.${SECRET_DOMAIN}/oauth/oidc/callback"
+            envFrom:
+              - secretRef:
+                  name: kanidm-open-webui-oidc
             resources:
               requests:
                 cpu: 500m

--- a/kubernetes/apps/main/media/komga/app/helmrelease.yaml
+++ b/kubernetes/apps/main/media/komga/app/helmrelease.yaml
@@ -26,6 +26,19 @@ spec:
               TZ: Europe/Paris
               SERVER_PORT: &port 8080
               KOMGA_CORS_ALLOWED_ORIGINS: https://komf.${SECRET_DOMAIN}
+              # OIDC via Kanidm. Client id/secret arrive via envFrom kanidm-komga-oidc
+              # (keys are the two SPRING_..._CLIENT_ID/_SECRET names). Spring is a
+              # confidential client and doesn't send PKCE → kanidm client disables it.
+              SERVER_FORWARD_HEADERS_STRATEGY: framework
+              SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KANIDM_CLIENT_NAME: Kanidm
+              SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KANIDM_SCOPE: openid,email,profile
+              SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KANIDM_CLIENT_AUTHENTICATION_METHOD: client_secret_basic
+              SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KANIDM_REDIRECT_URI: "{baseUrl}/login/oauth2/code/kanidm"
+              SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KANIDM_ISSUER_URI: https://idm.${SECRET_DOMAIN}/oauth2/openid/komga
+              SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_KANIDM_USER_NAME_ATTRIBUTE: email
+            envFrom:
+              - secretRef:
+                  name: kanidm-komga-oidc
             resources:
               requests:
                 cpu: 15m

--- a/kubernetes/apps/main/security/kanidm/app/provisioning/oauth2.yaml
+++ b/kubernetes/apps/main/security/kanidm/app/provisioning/oauth2.yaml
@@ -1,7 +1,9 @@
 ---
-# OAuth2 clients provisioned by kanidm-provision. Each ConfigMap targets one namespace;
-# the generated client secret is written back there as Secret `kanidm-<name>-oidc` with
-# the keys named by k8s.clientIdKey / k8s.clientSecretKey.
+# OAuth2 clients provisioned by kanidm-provision. One ConfigMap per target namespace
+# (data.targetNamespace is ConfigMap-level, not per-client). For each client the
+# provisioner writes Secret `kanidm-<name>-oidc` into that namespace with the keys named
+# by k8s.clientIdKey / k8s.clientSecretKey — chosen here to match each app's own env vars
+# so the app can consume the secret directly via `envFrom`.
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -26,6 +28,74 @@ data:
             "clientIdKey": "OIDC_CLIENT_ID",
             "clientSecretKey": "OIDC_CLIENT_SECRET",
             "imageUrl": "https://raw.githubusercontent.com/homarr-labs/dashboard-icons/main/svg/romm.svg"
+          }
+        },
+        "komga": {
+          "present": true, "displayName": "Komga",
+          "originUrl": "https://komga.${SECRET_DOMAIN}/login/oauth2/code/kanidm",
+          "originLanding": "https://komga.${SECRET_DOMAIN}/",
+          "scopeMaps": { "users": ["openid", "email", "profile"] },
+          "preferShortUsername": true,
+          "allowInsecureClientDisablePkce": true,
+          "k8s": {
+            "clientIdKey": "SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KANIDM_CLIENT_ID",
+            "clientSecretKey": "SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KANIDM_CLIENT_SECRET",
+            "imageUrl": "https://raw.githubusercontent.com/homarr-labs/dashboard-icons/main/svg/komga.svg"
+          }
+        }
+      } } }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kanidm-provision-oauth2-llm
+  labels:
+    kanidm_config: "1"
+  annotations:
+    reloader.stakater.com/match: "true"
+data:
+  targetNamespace: llm
+  oauth2.json: |
+    {
+      "groups": {}, "persons": {}, "systems": { "oauth2": {
+        "open-webui": {
+          "present": true, "displayName": "Open WebUI",
+          "originUrl": "https://chat.${SECRET_DOMAIN}/oauth/oidc/callback",
+          "originLanding": "https://chat.${SECRET_DOMAIN}/",
+          "scopeMaps": { "users": ["openid", "email", "profile"] },
+          "preferShortUsername": true,
+          "allowInsecureClientDisablePkce": true,
+          "k8s": {
+            "clientIdKey": "OAUTH_CLIENT_ID",
+            "clientSecretKey": "OAUTH_CLIENT_SECRET",
+            "imageUrl": "https://raw.githubusercontent.com/homarr-labs/dashboard-icons/main/svg/open-webui.svg"
+          }
+        }
+      } } }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kanidm-provision-oauth2-default
+  labels:
+    kanidm_config: "1"
+  annotations:
+    reloader.stakater.com/match: "true"
+data:
+  targetNamespace: default
+  oauth2.json: |
+    {
+      "groups": {}, "persons": {}, "systems": { "oauth2": {
+        "karakeep": {
+          "present": true, "displayName": "Karakeep",
+          "originUrl": "https://karakeep.${SECRET_DOMAIN}/api/auth/callback/custom",
+          "originLanding": "https://karakeep.${SECRET_DOMAIN}/",
+          "scopeMaps": { "users": ["openid", "email", "profile"] },
+          "preferShortUsername": true,
+          "k8s": {
+            "clientIdKey": "OAUTH_CLIENT_ID",
+            "clientSecretKey": "OAUTH_CLIENT_SECRET",
+            "imageUrl": "https://raw.githubusercontent.com/homarr-labs/dashboard-icons/main/svg/karakeep.svg"
           }
         }
       } } }


### PR DESCRIPTION
First wave of the kanidm SSO rollout (native-OIDC apps). Three apps that all take client-id/secret as **separate env vars**, so the kanidm-provisioned secret is consumed directly via `envFrom` — the client secret never touches git.

The trick: `kanidm-provision` lets me name the written secret keys, so each client's `clientIdKey`/`clientSecretKey` are set to the app's exact env-var names → the app just `envFrom`s `kanidm-<app>-oidc`.

| App | ns | Client / callback | PKCE | Notes |
|---|---|---|---|---|
| **komga** | media | `/login/oauth2/code/kanidm` | disabled | Spring Security confidential client; `SERVER_FORWARD_HEADERS_STRATEGY=framework` so the redirect is https; matches users by `email` |
| **open-webui** | llm | `/oauth/oidc/callback` | disabled | `OAUTH_*` + `OPENID_PROVIDER_URL`; `ENABLE_OAUTH_SIGNUP=true` |
| **karakeep** | default | `/api/auth/callback/custom` | **kept** | NextAuth generic OIDC; NextAuth sends PKCE |

All three keep username/password login enabled as a fallback, so a misconfig can't lock anyone out.

### Verify after merge (per app — click "Login with Kanidm")
- **komga** / **open-webui** ship with PKCE disabled (confidential/uncertain clients). If login errors, the knob is `allowInsecureClientDisablePkce` in `provisioning/oauth2.yaml`.
- Email in the app must match the kanidm account's email (same rule as romm).
- Brief `CreateContainerConfigError` possible until provision creates `kanidm-<app>-oidc`; self-heals.

Deferred to later waves: **grafana** (grafana-operator `Grafana` CR, not env), **immich** (OAuth configured in-DB), **paperless**/**nextcloud** (single-JSON-blob env — need special plumbing). Then bucket ③ (arrs, prometheus, qbittorrent…) via oauth2-proxy.

Validation: `kustomize build` + `kubeconform` pass for all four dirs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)