### PR TITLE
feat(sso): wave 2 native OIDC — grafana

### DIFF
--- a/kubernetes/apps/main/observability/grafana/instance/grafana.yaml
+++ b/kubernetes/apps/main/observability/grafana/instance/grafana.yaml
@@ -17,6 +17,21 @@ spec:
       disable_login_form: "false"
     auth.anonymous:
       enabled: "true"
+    auth.generic_oauth:
+      # Kanidm OIDC. client_id/secret come via envFrom kanidm-grafana-oidc
+      # (keys GF_AUTH_GENERIC_OAUTH_CLIENT_ID/_SECRET override these ini values).
+      # Grafana supports PKCE, so the kanidm client keeps PKCE required.
+      enabled: "true"
+      name: Kanidm
+      auth_url: "https://idm.${SECRET_DOMAIN}/ui/oauth2"
+      token_url: "https://idm.${SECRET_DOMAIN}/oauth2/token"
+      api_url: "https://idm.${SECRET_DOMAIN}/oauth2/openid/grafana/userinfo"
+      scopes: "openid email profile"
+      use_pkce: "true"
+      login_attribute_path: preferred_username
+      email_attribute_path: email
+      name_attribute_path: name
+      allow_sign_up: "true"
     log:
       mode: console
     metrics:
@@ -44,6 +59,10 @@ spec:
                     secretKeyRef:
                       name: grafana-admin-password-secret
                       key: GF_SECURITY_ADMIN_PASSWORD
+              envFrom:
+                # kanidm-provision writes GF_AUTH_GENERIC_OAUTH_CLIENT_ID/_SECRET here.
+                - secretRef:
+                    name: kanidm-grafana-oidc
               securityContext:
                 allowPrivilegeEscalation: false
                 readOnlyRootFilesystem: true

--- a/kubernetes/apps/main/security/kanidm/app/provisioning/oauth2.yaml
+++ b/kubernetes/apps/main/security/kanidm/app/provisioning/oauth2.yaml
@@ -99,3 +99,30 @@ data:
           }
         }
       } } }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kanidm-provision-oauth2-observability
+  labels:
+    kanidm_config: "1"
+  annotations:
+    reloader.stakater.com/match: "true"
+data:
+  targetNamespace: observability
+  oauth2.json: |
+    {
+      "groups": {}, "persons": {}, "systems": { "oauth2": {
+        "grafana": {
+          "present": true, "displayName": "Grafana",
+          "originUrl": "https://grafana.${SECRET_DOMAIN}/login/generic_oauth",
+          "originLanding": "https://grafana.${SECRET_DOMAIN}/",
+          "scopeMaps": { "users": ["openid", "email", "profile"] },
+          "preferShortUsername": true,
+          "k8s": {
+            "clientIdKey": "GF_AUTH_GENERIC_OAUTH_CLIENT_ID",
+            "clientSecretKey": "GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET",
+            "imageUrl": "https://raw.githubusercontent.com/homarr-labs/dashboard-icons/main/svg/grafana.svg"
+          }
+        }
+      } } }


### PR DESCRIPTION
Wave 2 of the kanidm SSO rollout. Adds **grafana** generic OAuth via the Grafana operator CR.

- kanidm `grafana` client (observability provisioning ConfigMap); secret `kanidm-grafana-oidc` with keys `GF_AUTH_GENERIC_OAUTH_CLIENT_ID`/`_SECRET`, consumed by the CR via `envFrom`.
- `auth.generic_oauth` in the `Grafana` CR: auth/token/userinfo endpoints, `use_pkce=true` (grafana supports PKCE, so **PKCE stays required** on the kanidm side — more secure than the Wave 1 apps), `allow_sign_up=true`, maps `preferred_username`/`email`/`name`.
- Local admin (`GF_SECURITY_ADMIN_PASSWORD`) and anonymous access unchanged.

### Why the batch is just grafana
Dug into the other candidates and they aren't clean env-OIDC:
- **qui** — no OIDC yet (upstream feature request autobrr/qui#298).
- **headlamp** — its OIDC passes the token to the kube-apiserver, so it needs **apiserver OIDC** configured in Talos (a much bigger change).
- **immich** — OAuth is configured in-DB / admin UI (no env).
- **paperless / nextcloud** — single JSON-blob env / `occ` (need special secret plumbing).

### Verify after merge
Click "Sign in with Kanidm" on grafana. New OIDC users land as org **Viewer** (role mapping via kanidm groups is a deliberate follow-up). No PKCE-disable here, so if login errors it's more likely a URL/claim mismatch than PKCE.

### Next
Wave 3 = stand up **oauth2-proxy** forward-auth (the approved bucket ③) to cover the no-native-auth apps — arrs, prometheus/alertmanager, qbittorrent, karma, victoria-logs, kopia — in one shot, recreating the old authentik-outpost pattern against kanidm.

Validation: `kustomize build` passes for the kanidm app and grafana instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)