### PR TITLE
feat(container): update image ghcr.io/rtuszik/photon-docker (2.2.0 → 2.3.0)

### DIFF
--- a/kubernetes/apps/main/default/photon/app/helmrelease.yaml
+++ b/kubernetes/apps/main/default/photon/app/helmrelease.yaml
@@ -22,9 +22,9 @@ spec:
           app: &photon
             image:
               repository: ghcr.io/rtuszik/photon-docker
-              tag: 2.2.0
-            command: ["uv"]
-            args: ["run", "--no-sync", "-m", "src.process_manager"]
+              tag: 2.3.0
+            command: ["/photon/.venv/bin/python"]
+            args: ["-m", "src.process_manager"]
             env:
               REGION: planet
               UPDATE_STRATEGY: SEQUENTIAL


### PR DESCRIPTION
Bumps `ghcr.io/rtuszik/photon-docker` `2.2.0` → `2.3.0` (wraps komoot/photon → 1.2.0). Supersedes Renovate PR #3469, which would break at runtime.

## Why the command override changed

v2.3.0 switched to a multi-stage build ([upstream #317](https://github.com/rtuszik/photon-docker/pull/317)) that **drops the `uv` binary from the final image**. The Dockerfile `CMD` changed to invoke the venv Python directly:

```dockerfile
CMD ["/photon/.venv/bin/python", "-m", "src.process_manager"]
```

This repo overrides `command: ["uv"]` / `args: ["run", "--no-sync", "-m", "src.process_manager"]`, which would fail with `command not found`. Updated to:

```yaml
command: ["/photon/.venv/bin/python"]
args: ["-m", "src.process_manager"]
```

The default `entrypoint.sh` can't be used instead because it needs root (`groupmod`/`usermod`/`gosu`) and our `securityContext` runs `runAsNonRoot` with `drop: ["ALL"]` and `readOnlyRootFilesystem`. Verified the `/photon/.venv` path and `CMD` against the upstream `2.3.0` Dockerfile.

> [!NOTE]
> v2.3.0 also adds experimental JSONL dump mode, but the default `db` mode used here is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)