### PR TITLE
fix(photon): run as non-root user 1000

### DIFF
--- a/kubernetes/apps/main/default/photon/app/helmrelease.yaml
+++ b/kubernetes/apps/main/default/photon/app/helmrelease.yaml
@@ -61,9 +61,9 @@ spec:
     defaultPodOptions:
       securityContext:
         runAsNonRoot: true
-        runAsUser: 9011
-        runAsGroup: 9011
-        fsGroup: 9011
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
         fsGroupChangePolicy: OnRootMismatch
     service:
       app:

--- a/kubernetes/apps/main/default/photon/app/helmrelease.yaml
+++ b/kubernetes/apps/main/default/photon/app/helmrelease.yaml
@@ -30,8 +30,6 @@ spec:
               UPDATE_STRATEGY: SEQUENTIAL
               UPDATE_INTERVAL: 30d
               ENABLE_METRICS: "TRUE"
-              PUID: 9011
-              PGID: 9011
             probes:
               liveness: &probe
                 enabled: true


### PR DESCRIPTION
Follow-up to #3616. Now that v2.3.0 invokes the venv Python directly (no `uv` at runtime), the container no longer needs the image-native user, so this switches it to run as **1000** and drops the now-dead `PUID`/`PGID` env vars.

## Why 1000 works now (it didn't before)

The old runtime command was `uv run --no-sync`, which needs a writable `~/.cache/uv`. That only existed for the image-native `photon` user (UID 9011, `HOME=/photon`, with the `/photon/.cache` emptyDir mounted). UID 1000 has no passwd entry so `HOME=/`, and under `readOnlyRootFilesystem` `uv` couldn't create its cache → it aborted. That's why the previous attempt was reverted to 9011.

v2.3.0's command is now `/photon/.venv/bin/python -m src.process_manager` — no `uv`, no cache/`$HOME` write requirement:
- The venv `python` symlinks to the system `/usr/bin/python3.12` present in the final `eclipse-temurin:21` stage.
- All app files under `/photon` stay world-readable (755/644) after the image's `chown`, so any UID can read them.
- Writes go only to fsGroup-owned volumes (`/photon/data`, `/photon/.cache`).

## Changes

- `PUID`/`PGID` env vars removed — only `entrypoint.sh` consumes them (gosu remapping), and we bypass the entrypoint via the `command` override, so they were no-ops.
- `runAsUser`/`runAsGroup`/`fsGroup`: `9011` → `1000`.

> [!NOTE]
> `fsGroup` 9011 → 1000 triggers a one-time recursive re-chown of the `data` PVC (planet index) via `fsGroupChangePolicy: OnRootMismatch` on next mount — expect one slow mount, then normal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)