### PR TITLE
fix(sso): RS256 legacy crypto for komga kanidm client

### DIFF
--- a/kubernetes/apps/main/security/kanidm/app/provisioning/oauth2.yaml
+++ b/kubernetes/apps/main/security/kanidm/app/provisioning/oauth2.yaml
@@ -37,6 +37,7 @@ data:
           "scopeMaps": { "users": ["openid", "email", "profile"] },
           "preferShortUsername": true,
           "allowInsecureClientDisablePkce": true,
+          "enableLegacyCrypto": true,
           "k8s": {
             "clientIdKey": "SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KANIDM_CLIENT_ID",
             "clientSecretKey": "SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_KANIDM_CLIENT_SECRET",


### PR DESCRIPTION
## Root cause (diagnosed from komga debug logs)

Komga login via kanidm failed **after** a successful token exchange with:

```
[invalid_id_token] Signed JWT rejected: Another algorithm expected, or no matching key(s) found
```

Kanidm signs id_tokens with **ES256** by default; komga's Spring Security decoder expects **RS256** and rejects it. (Not an email/account issue — email matching was a red herring; the flow never got past id_token validation.)

## Fix

Set `enableLegacyCrypto: true` on the komga OAuth2 client so kanidm signs its tokens with RS256. `kanidm-provision` applies it (`oauth2_jwt_legacy_crypto_enable`) on reconcile.

## Notes
- Only komga (Spring Security) needs this. romm/karakeep/open-webui use OIDC libs that accept ES256; grafana too.
- After merge, retry "Login with Kanidm" on komga — it should link to the komga user whose email matches your kanidm `mail` (`dev.home@wlab.ovh`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)