### PR TITLE
fix(photon): add supplementalGroups 9011 so uid 1000 can read /photon

### DIFF
--- a/kubernetes/apps/main/default/photon/app/helmrelease.yaml
+++ b/kubernetes/apps/main/default/photon/app/helmrelease.yaml
@@ -64,6 +64,9 @@ spec:
         runAsUser: 1000
         runAsGroup: 1000
         fsGroup: 1000
+        # image bakes /photon as 0750 owned by photon (uid/gid 9011); join that
+        # group so a non-9011 user can traverse it to reach the venv + src
+        supplementalGroups: [9011]
         fsGroupChangePolicy: OnRootMismatch
     service:
       app:


### PR DESCRIPTION
Hotfix for the CrashLoopBackOff introduced by #3617.

## Symptom
```
StartError: exec: "/photon/.venv/bin/python": stat /photon/.venv/bin/python: permission denied
```

## Root cause
My rationale in #3617 was wrong. Switching to uid 1000 didn't fail because of `uv` — it failed because the v2.3.0 image bakes the home dir as:

```
drwxr-x--- photon photon /photon      # 0750, owner+group = uid/gid 9011
```

`/photon` is mode **0750**, so "other" has no access. Uid 1000 is neither the owner nor in group 9011, so it can't even traverse into `/photon` to reach `/photon/.venv/bin/python` → container init fails before the app starts. (The venv subdirs are 0755; it's the top-level home dir that gates access.) This is the same constraint that originally drove the repo to "run as image-native user 9011".

## Fix
Add `supplementalGroups: [9011]` so the process joins the `photon` group. `0750` grants that group `r-x`, which is enough to traverse `/photon` and read the world-/group-readable venv, `src/`, and `photon.jar`. Writes are unaffected — they still target the `fsGroup: 1000` volumes (`/photon/data`, `/photon/.cache`).

## Verification
Ran the real `2.3.0` image as `runAsUser: 1000` / `supplementalGroups: [9011]` under `readOnlyRootFilesystem` + `drop: ALL`:
- `id` → `groups=1000(ubuntu),...,9011(photon)`
- `/photon/.venv/bin/python --version` → `Python 3.12.3`
- `cd /photon && python -c 'import src'` → `import OK`

> [!NOTE]
> This couples the manifest to the image's internal gid (9011). If you'd rather not depend on that, the alternative is reverting `runAsUser`/`runAsGroup`/`fsGroup` back to `9011` (the image-native user). This PR keeps uid 1000 as requested.

🤖 Generated with [Claude Code](https://claude.com/claude-code)