### PR TITLE
fix(sso): karakeep OIDC account linking by email

### DIFF
--- a/kubernetes/apps/main/default/karakeep/app/helmrelease.yaml
+++ b/kubernetes/apps/main/default/karakeep/app/helmrelease.yaml
@@ -36,6 +36,9 @@ spec:
               OAUTH_PROVIDER_NAME: Kanidm
               OAUTH_WELLKNOWN_URL: "https://idm.${SECRET_DOMAIN}/oauth2/openid/karakeep/.well-known/openid-configuration"
               OAUTH_SCOPE: "openid email profile"
+              # NextAuth refuses to link OIDC to an existing password account by email
+              # unless this is set — needed to sign into the pre-existing admin account.
+              OAUTH_ALLOW_DANGEROUS_EMAIL_ACCOUNT_LINKING: "true"
               DISABLE_PASSWORD_AUTH: false
               DISABLE_SIGNUPS: true
               DISABLE_NEW_RELEASE_CHECK: true


### PR DESCRIPTION
karakeep uses NextAuth, which refuses to link an OIDC login to an existing **password** account with the same email (throws `OAuthAccountNotLinked`, an account-takeover guard). Set `OAUTH_ALLOW_DANGEROUS_EMAIL_ACCOUNT_LINKING: "true"` so the kanidm login links into the pre-existing admin account.

Companion manual step already done: the karakeep admin user's email was changed in the DB from `dev.karakeep@wlab.ovh` → `dev.home@wlab.ovh` (matches the kanidm `mail`), since karakeep has no email-change UI (karakeep-app/karakeep#136). A DB backup was taken.

After merge, "Login with Kanidm" on karakeep should sign into the existing admin account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)