### PR TITLE
fix(sso): RS256 legacy crypto for karakeep kanidm client

### DIFF
--- a/kubernetes/apps/main/security/kanidm/app/provisioning/oauth2.yaml
+++ b/kubernetes/apps/main/security/kanidm/app/provisioning/oauth2.yaml
@@ -93,6 +93,7 @@ data:
           "originLanding": "https://karakeep.${SECRET_DOMAIN}/",
           "scopeMaps": { "users": ["openid", "email", "profile"] },
           "preferShortUsername": true,
+          "enableLegacyCrypto": true,
           "k8s": {
             "clientIdKey": "OAUTH_CLIENT_ID",
             "clientSecretKey": "OAUTH_CLIENT_SECRET",


### PR DESCRIPTION
Follow-up to #3620. With the email matched and account-linking enabled, karakeep's login now fails one layer deeper — same ES256/RS256 issue as komga (#3618):

```
[next-auth][error][OAUTH_CALLBACK_ERROR] unexpected JWT alg received, expected RS256, got: ES256
```

NextAuth v4 hardcodes RS256 for id_token validation. Set `enableLegacyCrypto: true` on the karakeep client so kanidm signs with RS256.

Turns out the ES256→RS256 issue isn't Spring-specific — NextAuth needs it too. Libraries that accept ES256 so far: romm (authlib), and presumably open-webui/grafana (to be verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)