### PR TITLE
feat(sso): grafana Admin via kanidm admins group (prep for OIDC-only)

### DIFF
--- a/kubernetes/apps/main/observability/grafana/instance/grafana.yaml
+++ b/kubernetes/apps/main/observability/grafana/instance/grafana.yaml
@@ -32,6 +32,8 @@ spec:
       email_attribute_path: email
       name_attribute_path: name
       allow_sign_up: "true"
+      # kanidm emits grafana_role via claimMap (admins→Admin, users→Viewer).
+      role_attribute_path: "contains(grafana_role[*], 'Admin') && 'Admin' || 'Viewer'"
     log:
       mode: console
     metrics:

--- a/kubernetes/apps/main/security/kanidm/app/provisioning/groups.yaml
+++ b/kubernetes/apps/main/security/kanidm/app/provisioning/groups.yaml
@@ -13,8 +13,8 @@ data:
   groups.json: |-
     {
       "groups": {
-        "users":  { "present": true, "members": [], "overwriteMembers": false },
-        "admins": { "present": true, "members": [], "overwriteMembers": false }
+        "users":  { "present": true, "members": ["hugo"], "overwriteMembers": false },
+        "admins": { "present": true, "members": ["hugo"], "overwriteMembers": false }
       },
       "persons": {},
       "systems": { "oauth2": {} }

--- a/kubernetes/apps/main/security/kanidm/app/provisioning/oauth2.yaml
+++ b/kubernetes/apps/main/security/kanidm/app/provisioning/oauth2.yaml
@@ -120,6 +120,12 @@ data:
           "originLanding": "https://grafana.${SECRET_DOMAIN}/",
           "scopeMaps": { "users": ["openid", "email", "profile"] },
           "preferShortUsername": true,
+          "claimMaps": {
+            "grafana_role": {
+              "joinType": "array",
+              "valuesByGroup": { "admins": ["Admin"], "users": ["Viewer"] }
+            }
+          },
           "k8s": {
             "clientIdKey": "GF_AUTH_GENERIC_OAUTH_CLIENT_ID",
             "clientSecretKey": "GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET",


### PR DESCRIPTION
Groundwork so we can safely disable grafana's password login (your ask) without locking you into Viewer-only.

**Why needed:** your `hugo` account is in `users` but **not** `admins`, and grafana OIDC users currently default to Viewer. Disabling the login form now would strip your admin access.

**This PR (login form stays enabled):**
1. Add `hugo` to the `admins` group (`provisioning/groups.yaml`).
2. kanidm emits a `grafana_role` claim via `claimMap` (admins→`Admin`, users→`Viewer`).
3. Grafana maps it: `role_attribute_path: contains(grafana_role[*], 'Admin') && 'Admin' || 'Viewer'`.

**After merge:** sign into grafana with kanidm and confirm you land as **Admin** (top-left → your profile → role, or you can see admin menus). 

**Then** the follow-up is a one-liner — `auth.disable_login_form: "true"` — which hides username/password entirely (OIDC-only). Break-glass remains: the local admin still works via HTTP basic auth on the API, and reverting the flag restores the form.

Note: grafana OIDC itself (#3611) uses ES256 which Go's go-oidc handles, so no `enableLegacyCrypto` expected here — but if login fails at id_token validation, that's the same flag we flipped for komga/karakeep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)