### PR TITLE
feat(sso): grafana OIDC-only (disable login form + anonymous)

### DIFF
--- a/kubernetes/apps/main/observability/grafana/instance/grafana.yaml
+++ b/kubernetes/apps/main/observability/grafana/instance/grafana.yaml
@@ -14,9 +14,11 @@ spec:
       feedback_links_enabled: "false"
       reporting_enabled: "false"
     auth:
-      disable_login_form: "false"
+      # OIDC-only: hide the username/password form. Local admin still works via
+      # HTTP basic-auth on the API (break-glass); revert this to re-show the form.
+      disable_login_form: "true"
     auth.anonymous:
-      enabled: "true"
+      enabled: "false"
     auth.generic_oauth:
       # Kanidm OIDC. client_id/secret come via envFrom kanidm-grafana-oidc
       # (keys GF_AUTH_GENERIC_OAUTH_CLIENT_ID/_SECRET override these ini values).


### PR DESCRIPTION
Follow-up to #3622 (which mapped your kanidm `admins` group → Grafana Admin, verified: `hugo` is now in `admins`).

- `auth.disable_login_form: "true"` — hides username/password; grafana is kanidm-only.
- `auth.anonymous.enabled: "false"` — no more unauthenticated dashboard viewing.

**Break-glass preserved:** the local admin account is untouched — it still authenticates via HTTP basic-auth on the grafana API, and reverting `disable_login_form` (1-line git change, Flux applies in ~1min) brings the form back. The admin password stays in Bitwarden.

After merge: hitting grafana shows only "Sign in with Kanidm", and you land as Admin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)