### PR TITLE
fix(sso): open-webui merge OIDC account by email

### DIFF
--- a/kubernetes/apps/main/llm/open-webui/app/helmrelease.yaml
+++ b/kubernetes/apps/main/llm/open-webui/app/helmrelease.yaml
@@ -48,6 +48,9 @@ spec:
               # OIDC via Kanidm. OAUTH_CLIENT_ID/SECRET arrive via envFrom kanidm-open-webui-oidc.
               WEBUI_URL: "https://chat.${SECRET_DOMAIN}"
               ENABLE_OAUTH_SIGNUP: "true"
+              # Link the kanidm login onto the existing account with the same email
+              # instead of erroring "email already registered".
+              OAUTH_MERGE_ACCOUNTS_BY_EMAIL: "true"
               OAUTH_PROVIDER_NAME: Kanidm
               OAUTH_SCOPES: "openid email profile"
               OPENID_PROVIDER_URL: "https://idm.${SECRET_DOMAIN}/oauth2/openid/open-webui/.well-known/openid-configuration"


### PR DESCRIPTION
Open WebUI login via kanidm failed with *"This email is already registered. Sign in with your existing account or choose another email."* — it matched an existing password account by email but won't link automatically.

Set `OAUTH_MERGE_ACCOUNTS_BY_EMAIL: "true"` so the kanidm login links onto the existing account.

Good news: open-webui got *past* id_token validation to the account step, confirming its OAuth lib (authlib) handles kanidm's ES256 — no `enableLegacyCrypto` needed (unlike komga/karakeep).

After merge, retry "Sign in with Kanidm" on open-webui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)