### PR TITLE
feat(sso): reusable oidc-auth component + karma pilot

### DIFF
--- a/kubernetes/apps/main/observability/karma/ks.yaml
+++ b/kubernetes/apps/main/observability/karma/ks.yaml
@@ -10,6 +10,8 @@ spec:
   commonMetadata:
     labels:
       app.kubernetes.io/name: *app
+  components:
+    - ../../../../../components/oidc-auth
   path: ./kubernetes/apps/main/observability/karma/app
   prune: true
   sourceRef:

--- a/kubernetes/apps/main/security/kanidm/app/provisioning/oauth2.yaml
+++ b/kubernetes/apps/main/security/kanidm/app/provisioning/oauth2.yaml
@@ -132,5 +132,18 @@ data:
             "clientSecretKey": "GF_AUTH_GENERIC_OAUTH_CLIENT_SECRET",
             "imageUrl": "https://raw.githubusercontent.com/homarr-labs/dashboard-icons/main/svg/grafana.svg"
           }
+        },
+        "karma": {
+          "present": true, "displayName": "Karma",
+          "originUrl": "https://karma.${SECRET_DOMAIN}/oauth2/callback",
+          "originLanding": "https://karma.${SECRET_DOMAIN}/",
+          "scopeMaps": { "users": ["openid", "email", "profile"] },
+          "preferShortUsername": true,
+          "allowInsecureClientDisablePkce": true,
+          "k8s": {
+            "clientIdKey": "client-id",
+            "clientSecretKey": "client-secret",
+            "imageUrl": "https://raw.githubusercontent.com/homarr-labs/dashboard-icons/main/svg/prometheus.svg"
+          }
         }
       } } }

--- a/kubernetes/components/oidc-auth/kustomization.yaml
+++ b/kubernetes/components/oidc-auth/kustomization.yaml
@@ -1,0 +1,6 @@
+---
+# yaml-language-server: $schema=https://json.schemastore.org/kustomization
+apiVersion: kustomize.config.k8s.io/v1alpha1
+kind: Component
+resources:
+  - ./securitypolicy.yaml

--- a/kubernetes/components/oidc-auth/securitypolicy.yaml
+++ b/kubernetes/components/oidc-auth/securitypolicy.yaml
@@ -1,0 +1,36 @@
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.envoyproxy.io/securitypolicy_v1alpha1.json
+# Reusable forward-auth: gate an HTTPRoute with Envoy Gateway's native OIDC against
+# kanidm — no oauth2-proxy / no per-app auth pod. Add to an app's ks.yaml:
+#   spec:
+#     components: [../../../../../components/oidc-auth]
+#     postBuild:
+#       substitute:
+#         APP: <app>                       # kanidm client name + default host/route
+#         # OIDC_HOST: custom.${SECRET_DOMAIN}   (optional, defaults to ${APP}.${SECRET_DOMAIN})
+#         # OIDC_TARGET: <httproute-name>        (optional, defaults to ${APP})
+# Requires a matching kanidm-provision client named ${APP} with
+# allowInsecureClientDisablePkce (EG's OIDC flow sends no PKCE, kanidm enforces it)
+# and k8s.clientSecretKey "client-secret" → secret kanidm-${APP}-oidc.
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: ${APP}
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: ${OIDC_TARGET:=${APP}}
+  oidc:
+    provider:
+      issuer: https://idm.${SECRET_DOMAIN}/oauth2/openid/${APP}
+    clientID: ${APP}
+    clientSecret:
+      name: kanidm-${APP}-oidc
+    redirectURL: https://${OIDC_HOST:=${APP}.${SECRET_DOMAIN}}/oauth2/callback
+    logoutPath: /logout
+    cookieDomain: ${OIDC_HOST:=${APP}.${SECRET_DOMAIN}}
+    scopes:
+      - "openid"
+      - "email"
+      - "profile"


### PR DESCRIPTION
Forward-auth for the **no-native-auth** apps (arrs, prometheus, qbittorrent…) via **Envoy Gateway's native OIDC** — no oauth2-proxy, no per-app auth pod. Packaged as a reusable Kustomize **Component**, modeled on [vrozaksen/home-ops `components/oidc-auth`](https://github.com/vrozaksen/home-ops/tree/main/kubernetes/components/oidc-auth).

### `components/oidc-auth`
Renders a `SecurityPolicy` from placeholders. Gating any app becomes two small edits:

```yaml
# <app>/ks.yaml
spec:
  components:
    - ../../../../../components/oidc-auth
  postBuild:
    substitute:
      APP: <app>                 # kanidm client name + default host/route
      # OIDC_HOST: custom.${SECRET_DOMAIN}   (optional)
      # OIDC_TARGET: <httproute>             (optional, defaults to APP)
```
…plus a kanidm-provision client named `<app>` with `allowInsecureClientDisablePkce` (EG's OIDC flow sends no PKCE) and `clientSecretKey: client-secret` → secret `kanidm-<app>-oidc`.

### Pilot: karma
Wired karma to the component (no app-side change — karma has no auth of its own). External issuer via auto-discovery (kanidm has a valid LE cert, so no explicit `Backend`).

### Verify after merge — gates access, watch closely
1. `https://karma.wlab.ovh` → redirect to kanidm → back → karma.
2. **Risk:** envoy must reach the issuer at `idm.wlab.ovh` (hairpin through the external gateway). If discovery fails, the SecurityPolicy shows not-accepted and karma 500s → fix is `provider.backendRefs` → a `Backend` pointing at the in-cluster kanidm svc. I'll check SecurityPolicy status post-merge.
3. Break-glass: karma had no auth before — delete the SecurityPolicy to restore open access.

If the pilot holds, rolling out the rest is: add a kanidm client + `components: [oidc-auth]` per app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)