### PR TITLE
feat(sso): forward-auth batch — victoria-logs, kopia, prometheus, alertmanager

### DIFF
--- a/kubernetes/apps/main/observability/kube-prometheus-stack/app/kustomization.yaml
+++ b/kubernetes/apps/main/observability/kube-prometheus-stack/app/kustomization.yaml
@@ -8,3 +8,4 @@ resources:
   - ./grafanadashboard.yaml
   - ./helmrelease.yaml
   - ./scrapeconfig.yaml
+  - ./securitypolicy.yaml

--- a/kubernetes/apps/main/observability/kube-prometheus-stack/app/securitypolicy.yaml
+++ b/kubernetes/apps/main/observability/kube-prometheus-stack/app/securitypolicy.yaml
@@ -1,0 +1,47 @@
+---
+# Forward-auth via Envoy Gateway native OIDC. prometheus + alertmanager share one
+# ks.yaml, so they can't use the per-app components/oidc-auth (which is driven by a
+# single ${APP}); the policies are declared explicitly here instead.
+# Clients (prometheus, alertmanager) are provisioned by kanidm-provision →
+# secrets kanidm-<name>-oidc (key client-secret) in this namespace.
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.envoyproxy.io/securitypolicy_v1alpha1.json
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: prometheus
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: kube-prometheus-stack-prometheus
+  oidc:
+    provider:
+      issuer: https://idm.${SECRET_DOMAIN}/oauth2/openid/prometheus
+    clientID: prometheus
+    clientSecret:
+      name: kanidm-prometheus-oidc
+    redirectURL: https://prometheus.${SECRET_DOMAIN}/oauth2/callback
+    logoutPath: /logout
+    cookieDomain: prometheus.${SECRET_DOMAIN}
+    scopes: ["openid", "email", "profile"]
+---
+# yaml-language-server: $schema=https://kubernetes-schemas.pages.dev/gateway.envoyproxy.io/securitypolicy_v1alpha1.json
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: SecurityPolicy
+metadata:
+  name: alertmanager
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: kube-prometheus-stack-alertmanager
+  oidc:
+    provider:
+      issuer: https://idm.${SECRET_DOMAIN}/oauth2/openid/alertmanager
+    clientID: alertmanager
+    clientSecret:
+      name: kanidm-alertmanager-oidc
+    redirectURL: https://alertmanager.${SECRET_DOMAIN}/oauth2/callback
+    logoutPath: /logout
+    cookieDomain: alertmanager.${SECRET_DOMAIN}
+    scopes: ["openid", "email", "profile"]

--- a/kubernetes/apps/main/observability/victoria-logs/ks.yaml
+++ b/kubernetes/apps/main/observability/victoria-logs/ks.yaml
@@ -5,6 +5,8 @@ kind: Kustomization
 metadata:
   name: victoria-logs
 spec:
+  components:
+    - ../../../../../components/oidc-auth
   dependsOn:
     - name: rook-ceph
       namespace: rook-ceph
@@ -17,3 +19,7 @@ spec:
     namespace: flux-system
   targetNamespace: observability
   wait: false
+  postBuild:
+    substitute:
+      APP: victoria-logs
+      OIDC_TARGET: victoria-logs-server

--- a/kubernetes/apps/main/security/kanidm/app/provisioning/oauth2.yaml
+++ b/kubernetes/apps/main/security/kanidm/app/provisioning/oauth2.yaml
@@ -143,7 +143,74 @@ data:
           "k8s": {
             "clientIdKey": "client-id",
             "clientSecretKey": "client-secret",
+            "imageUrl": "https://raw.githubusercontent.com/homarr-labs/dashboard-icons/main/svg/karma.svg"
+          }
+        },
+        "victoria-logs": {
+          "present": true, "displayName": "VictoriaLogs",
+          "originUrl": "https://victoria-logs.${SECRET_DOMAIN}/oauth2/callback",
+          "originLanding": "https://victoria-logs.${SECRET_DOMAIN}/",
+          "scopeMaps": { "users": ["openid", "email", "profile"] },
+          "preferShortUsername": true,
+          "allowInsecureClientDisablePkce": true,
+          "k8s": {
+            "clientIdKey": "client-id",
+            "clientSecretKey": "client-secret",
+            "imageUrl": "https://raw.githubusercontent.com/homarr-labs/dashboard-icons/main/svg/victoriametrics.svg"
+          }
+        },
+        "prometheus": {
+          "present": true, "displayName": "Prometheus",
+          "originUrl": "https://prometheus.${SECRET_DOMAIN}/oauth2/callback",
+          "originLanding": "https://prometheus.${SECRET_DOMAIN}/",
+          "scopeMaps": { "users": ["openid", "email", "profile"] },
+          "preferShortUsername": true,
+          "allowInsecureClientDisablePkce": true,
+          "k8s": {
+            "clientIdKey": "client-id",
+            "clientSecretKey": "client-secret",
             "imageUrl": "https://raw.githubusercontent.com/homarr-labs/dashboard-icons/main/svg/prometheus.svg"
+          }
+        },
+        "alertmanager": {
+          "present": true, "displayName": "Alertmanager",
+          "originUrl": "https://alertmanager.${SECRET_DOMAIN}/oauth2/callback",
+          "originLanding": "https://alertmanager.${SECRET_DOMAIN}/",
+          "scopeMaps": { "users": ["openid", "email", "profile"] },
+          "preferShortUsername": true,
+          "allowInsecureClientDisablePkce": true,
+          "k8s": {
+            "clientIdKey": "client-id",
+            "clientSecretKey": "client-secret",
+            "imageUrl": "https://raw.githubusercontent.com/homarr-labs/dashboard-icons/main/svg/prometheus.svg"
+          }
+        }
+      } } }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kanidm-provision-oauth2-storage
+  labels:
+    kanidm_config: "1"
+  annotations:
+    reloader.stakater.com/match: "true"
+data:
+  targetNamespace: storage
+  oauth2.json: |
+    {
+      "groups": {}, "persons": {}, "systems": { "oauth2": {
+        "kopia": {
+          "present": true, "displayName": "Kopia",
+          "originUrl": "https://kopia.${SECRET_DOMAIN}/oauth2/callback",
+          "originLanding": "https://kopia.${SECRET_DOMAIN}/",
+          "scopeMaps": { "users": ["openid", "email", "profile"] },
+          "preferShortUsername": true,
+          "allowInsecureClientDisablePkce": true,
+          "k8s": {
+            "clientIdKey": "client-id",
+            "clientSecretKey": "client-secret",
+            "imageUrl": "https://raw.githubusercontent.com/homarr-labs/dashboard-icons/main/svg/kopia.svg"
           }
         }
       } } }

--- a/kubernetes/apps/main/storage/kopia/ks.yaml
+++ b/kubernetes/apps/main/storage/kopia/ks.yaml
@@ -12,6 +12,7 @@ spec:
       app.kubernetes.io/name: *app
   components:
     - ../../../../../components/zeroscaler
+    - ../../../../../components/oidc-auth
   path: ./kubernetes/apps/main/storage/kopia/app
   prune: true
   sourceRef:


### PR DESCRIPTION
Gates four no-native-auth dashboards behind kanidm via Envoy Gateway OIDC (the `oidc-auth` component from the karma pilot). All read-only UIs, so no app-side changes and no double-login.

| app | wiring | kanidm client |
|---|---|---|
| kopia | `components: [oidc-auth]` (APP already set) | `kopia` (storage ns) |
| victoria-logs | component + `APP` + `OIDC_TARGET: victoria-logs-server` | `victoria-logs` (observability) |
| prometheus | explicit SecurityPolicy (shared ks.yaml) → `kube-prometheus-stack-prometheus` | `prometheus` |
| alertmanager | explicit SecurityPolicy → `kube-prometheus-stack-alertmanager` | `alertmanager` |

All clients: `allowInsecureClientDisablePkce` (EG sends no PKCE), `clientSecretKey: client-secret`.

Verify after merge: each host redirects to kanidm and back. Same hairpin caveat as the karma pilot (envoy → idm.wlab.ovh discovery); karma already proved it works, so these should too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)