### PR TITLE
feat(sso): forward-auth for the *arrs

### DIFF
--- a/kubernetes/apps/main/downloads/bazarr/ks.yaml
+++ b/kubernetes/apps/main/downloads/bazarr/ks.yaml
@@ -13,6 +13,7 @@ spec:
   components:
     - ../../../../../components/zeroscaler
     - ../../../../../components/volsync
+    - ../../../../../components/oidc-auth
 
   path: ./kubernetes/apps/main/downloads/bazarr/app
   prune: true

--- a/kubernetes/apps/main/downloads/prowlarr/ks.yaml
+++ b/kubernetes/apps/main/downloads/prowlarr/ks.yaml
@@ -12,6 +12,7 @@ spec:
       app.kubernetes.io/name: *app
   components:
     - ../../../../../components/volsync
+    - ../../../../../components/oidc-auth
 
   path: ./kubernetes/apps/main/downloads/prowlarr/app
   prune: true

--- a/kubernetes/apps/main/downloads/radarr-uhd/ks.yaml
+++ b/kubernetes/apps/main/downloads/radarr-uhd/ks.yaml
@@ -13,6 +13,7 @@ spec:
   components:
     - ../../../../../components/zeroscaler
     - ../../../../../components/volsync
+    - ../../../../../components/oidc-auth
 
   path: ./kubernetes/apps/main/downloads/radarr-uhd/app
   prune: true

--- a/kubernetes/apps/main/downloads/radarr/ks.yaml
+++ b/kubernetes/apps/main/downloads/radarr/ks.yaml
@@ -13,6 +13,7 @@ spec:
   components:
     - ../../../../../components/zeroscaler
     - ../../../../../components/volsync
+    - ../../../../../components/oidc-auth
 
   path: ./kubernetes/apps/main/downloads/radarr/app
   prune: true

--- a/kubernetes/apps/main/downloads/sonarr-anm/ks.yaml
+++ b/kubernetes/apps/main/downloads/sonarr-anm/ks.yaml
@@ -13,6 +13,7 @@ spec:
   components:
     - ../../../../../components/zeroscaler
     - ../../../../../components/volsync
+    - ../../../../../components/oidc-auth
 
   path: ./kubernetes/apps/main/downloads/sonarr-anm/app
   prune: true

--- a/kubernetes/apps/main/downloads/sonarr-tv/ks.yaml
+++ b/kubernetes/apps/main/downloads/sonarr-tv/ks.yaml
@@ -13,6 +13,7 @@ spec:
   components:
     - ../../../../../components/zeroscaler
     - ../../../../../components/volsync
+    - ../../../../../components/oidc-auth
 
   path: ./kubernetes/apps/main/downloads/sonarr-tv/app
   prune: true

--- a/kubernetes/apps/main/security/kanidm/app/provisioning/oauth2.yaml
+++ b/kubernetes/apps/main/security/kanidm/app/provisioning/oauth2.yaml
@@ -214,3 +214,26 @@ data:
           }
         }
       } } }
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kanidm-provision-oauth2-downloads
+  labels:
+    kanidm_config: "1"
+  annotations:
+    reloader.stakater.com/match: "true"
+data:
+  targetNamespace: downloads
+  # Forward-auth (Envoy Gateway OIDC) for the *arrs. These already run with
+  # AUTH__METHOD=External (their own login disabled), so this adds the only auth.
+  oauth2.json: |
+    {
+      "groups": {}, "persons": {}, "systems": { "oauth2": {
+        "radarr":     { "present": true, "displayName": "Radarr",     "originUrl": "https://radarr.${SECRET_DOMAIN}/oauth2/callback",     "originLanding": "https://radarr.${SECRET_DOMAIN}/",     "scopeMaps": { "users": ["openid","email","profile"] }, "preferShortUsername": true, "allowInsecureClientDisablePkce": true, "k8s": { "clientIdKey": "client-id", "clientSecretKey": "client-secret", "imageUrl": "https://raw.githubusercontent.com/homarr-labs/dashboard-icons/main/svg/radarr.svg" } },
+        "radarr-uhd": { "present": true, "displayName": "Radarr UHD", "originUrl": "https://radarr-uhd.${SECRET_DOMAIN}/oauth2/callback", "originLanding": "https://radarr-uhd.${SECRET_DOMAIN}/", "scopeMaps": { "users": ["openid","email","profile"] }, "preferShortUsername": true, "allowInsecureClientDisablePkce": true, "k8s": { "clientIdKey": "client-id", "clientSecretKey": "client-secret", "imageUrl": "https://raw.githubusercontent.com/homarr-labs/dashboard-icons/main/svg/radarr.svg" } },
+        "sonarr-anm": { "present": true, "displayName": "Sonarr Anime", "originUrl": "https://sonarr-anm.${SECRET_DOMAIN}/oauth2/callback", "originLanding": "https://sonarr-anm.${SECRET_DOMAIN}/", "scopeMaps": { "users": ["openid","email","profile"] }, "preferShortUsername": true, "allowInsecureClientDisablePkce": true, "k8s": { "clientIdKey": "client-id", "clientSecretKey": "client-secret", "imageUrl": "https://raw.githubusercontent.com/homarr-labs/dashboard-icons/main/svg/sonarr.svg" } },
+        "sonarr-tv":  { "present": true, "displayName": "Sonarr TV",  "originUrl": "https://sonarr-tv.${SECRET_DOMAIN}/oauth2/callback",  "originLanding": "https://sonarr-tv.${SECRET_DOMAIN}/",  "scopeMaps": { "users": ["openid","email","profile"] }, "preferShortUsername": true, "allowInsecureClientDisablePkce": true, "k8s": { "clientIdKey": "client-id", "clientSecretKey": "client-secret", "imageUrl": "https://raw.githubusercontent.com/homarr-labs/dashboard-icons/main/svg/sonarr.svg" } },
+        "prowlarr":   { "present": true, "displayName": "Prowlarr",   "originUrl": "https://prowlarr.${SECRET_DOMAIN}/oauth2/callback",   "originLanding": "https://prowlarr.${SECRET_DOMAIN}/",   "scopeMaps": { "users": ["openid","email","profile"] }, "preferShortUsername": true, "allowInsecureClientDisablePkce": true, "k8s": { "clientIdKey": "client-id", "clientSecretKey": "client-secret", "imageUrl": "https://raw.githubusercontent.com/homarr-labs/dashboard-icons/main/svg/prowlarr.svg" } },
+        "bazarr":     { "present": true, "displayName": "Bazarr",     "originUrl": "https://bazarr.${SECRET_DOMAIN}/oauth2/callback",     "originLanding": "https://bazarr.${SECRET_DOMAIN}/",     "scopeMaps": { "users": ["openid","email","profile"] }, "preferShortUsername": true, "allowInsecureClientDisablePkce": true, "k8s": { "clientIdKey": "client-id", "clientSecretKey": "client-secret", "imageUrl": "https://raw.githubusercontent.com/homarr-labs/dashboard-icons/main/svg/bazarr.svg" } }
+      } } }


### PR DESCRIPTION
Gates **radarr, radarr-uhd, sonarr-anm, sonarr-tv, prowlarr, bazarr** behind kanidm via the `oidc-auth` component.

**No double-login:** all five .NET arrs already run with `<APP>__AUTH__METHOD: External` + `__AUTH__REQUIRED: DisabledForLocalAddresses` — their own login is disabled, so they were effectively **unprotected**. This adds the only auth wall in front of them. bazarr defaults to no auth too.

Each: `components: [oidc-auth]` in its ks.yaml (APP + route name already match) + a kanidm client in the new `downloads` provisioning ConfigMap (`allowInsecureClientDisablePkce`, `client-secret`).

### Verify after merge
Each `*.wlab.ovh` redirects to kanidm → back → the app. Since arr auth is External, you land straight in with no second prompt.

**Note:** API clients that talk to these arrs (Prowlarr↔Radarr/Sonarr sync, Bazarr, overseerr/requestts, recyclarr) use the **internal service DNS** (`http://radarr.downloads.svc…`), which bypasses the gateway/SecurityPolicy entirely — so forward-auth won't break inter-app API traffic. Only browser access via the external hostname is gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)