### PR TITLE
feat(observability): gatus auth-gate fail-open checks

### DIFF
--- a/kubernetes/apps/main/observability/gatus/app/prometheusrule.yaml
+++ b/kubernetes/apps/main/observability/gatus/app/prometheusrule.yaml
@@ -27,3 +27,14 @@ spec:
               The {{ $labels.name }} endpoint has a public DNS record and is exposed
           labels:
             severity: critical
+
+        - alert: GatusAuthGateFailing
+          expr: |-
+            gatus_results_endpoint_success{group="auth-gate"} == 0
+          for: 5m
+          annotations:
+            summary: >-
+              Auth gate for {{ $labels.name }} is not enforcing — SecurityPolicy
+              failed open (app exposed) or kanidm is unreachable
+          labels:
+            severity: critical

--- a/kubernetes/apps/main/observability/gatus/app/resources/config.yaml
+++ b/kubernetes/apps/main/observability/gatus/app/resources/config.yaml
@@ -42,6 +42,34 @@ endpoints:
     conditions:
       - "[CERTIFICATE_EXPIRATION] > 240h"
 
+  # --- Forward-auth gate verification (fail-open / IdP-down detection) ---
+  # These apps have no native auth (arrs run AUTH__METHOD=External); their only
+  # protection is the Envoy Gateway OIDC SecurityPolicy. Each check hits the app
+  # unauthenticated and follows the redirect: a healthy gate lands on the kanidm
+  # login page (body contains "Kanidm"). If the SecurityPolicy fails open (missing/
+  # invalid/deleted) the app serves its own content → check red → GatusAuthGateFailing.
+  # Centralized here (not per-route annotations) to keep the shared client/conditions
+  # defined once; dns-resolver = k8s-gateway (resolves internal hosts to the gateway).
+  - name: karma
+    group: &ag auth-gate
+    url: https://karma.${SECRET_DOMAIN}/
+    interval: &agi 5m
+    client: &agc
+      dns-resolver: tcp://192.168.1.200:53
+    conditions: &agcond
+      - "[STATUS] == 200"
+      - "[BODY] == pat(*Kanidm*)"
+  - { name: victoria-logs, group: *ag, url: "https://victoria-logs.${SECRET_DOMAIN}/", interval: *agi, client: *agc, conditions: *agcond }
+  - { name: prometheus,    group: *ag, url: "https://prometheus.${SECRET_DOMAIN}/",    interval: *agi, client: *agc, conditions: *agcond }
+  - { name: alertmanager,  group: *ag, url: "https://alertmanager.${SECRET_DOMAIN}/",  interval: *agi, client: *agc, conditions: *agcond }
+  - { name: kopia,         group: *ag, url: "https://kopia.${SECRET_DOMAIN}/",         interval: *agi, client: *agc, conditions: *agcond }
+  - { name: radarr,        group: *ag, url: "https://radarr.${SECRET_DOMAIN}/",        interval: *agi, client: *agc, conditions: *agcond }
+  - { name: radarr-uhd,    group: *ag, url: "https://radarr-uhd.${SECRET_DOMAIN}/",    interval: *agi, client: *agc, conditions: *agcond }
+  - { name: sonarr-anm,    group: *ag, url: "https://sonarr-anm.${SECRET_DOMAIN}/",    interval: *agi, client: *agc, conditions: *agcond }
+  - { name: sonarr-tv,     group: *ag, url: "https://sonarr-tv.${SECRET_DOMAIN}/",     interval: *agi, client: *agc, conditions: *agcond }
+  - { name: prowlarr,      group: *ag, url: "https://prowlarr.${SECRET_DOMAIN}/",      interval: *agi, client: *agc, conditions: *agcond }
+  - { name: bazarr,        group: *ag, url: "https://bazarr.${SECRET_DOMAIN}/",        interval: *agi, client: *agc, conditions: *agcond }
+
 metrics: true
 
 storage:


### PR DESCRIPTION
Monitors that each forward-auth-gated app is actually enforcing OIDC — detects the fail-open case (SecurityPolicy missing/invalid/deleted while the app has no native auth) *and* kanidm being down.

### DRY, centralized (not per-route annotations)
I first did this as `gatus.home-operations.com/endpoint` annotations per route, but the block is identical for all 11 apps and **can't be shared** across per-route annotations:
- routes are Helm-rendered, so kustomize / the oidc-auth component / YAML anchors can't reach them;
- the sidecar's Gateway→HTTPRoute inheritance would apply the check to *every* internal route (plex, tautulli, …) and false-fail the ungated ones.

So it's centralized in `gatus/resources/config.yaml` with **YAML anchors** — shared `client` + `conditions` defined once (`&agc`/`&agcond`), one line per app. ~15 lines total vs. 70 lines of scattered annotation.

### How the check works (behavioral, not CRD-status)
Gatus can't read a SecurityPolicy's `Accepted` condition, so each check hits the app **unauthenticated** and follows the redirect:
- **Gate healthy:** app → 302 → kanidm → login page → body contains `Kanidm` → ✅
- **Fail-open:** app serves its own content (no `Kanidm`) → ❌ → **GatusAuthGateFailing** (critical) → Alertmanager

(Confirmed against the live karma gate. The naive "expect 302" doesn't work — ungated apps 302 to their own UI, so the kanidm login body is the reliable signal.)

Covers all 11 gated apps: karma, victoria-logs, prometheus, alertmanager, kopia, radarr, radarr-uhd, sonarr-anm, sonarr-tv, prowlarr, bazarr. `dns-resolver: 192.168.1.200` (k8s-gateway) resolves internal hosts to the internal gateway. A fail-open is distinguishable from an IdP outage: auth-gate red **while** the kanidm endpoint check stays green.

**Merge after #3635** so the arr gates exist before their checks go live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)