### PR TITLE
fix(observability): gatus auth-gate resolver must be udp (stop false alerts)

### DIFF
--- a/kubernetes/apps/main/observability/gatus/app/resources/config.yaml
+++ b/kubernetes/apps/main/observability/gatus/app/resources/config.yaml
@@ -55,7 +55,8 @@ endpoints:
     url: https://karma.${SECRET_DOMAIN}/
     interval: &agi 5m
     client: &agc
-      dns-resolver: tcp://192.168.1.200:53
+      # k8s-gateway DNS listens on UDP only — tcp:// hangs and the check times out.
+      dns-resolver: udp://192.168.1.200:53
     conditions: &agcond
       - "[STATUS] == 200"
       - "[BODY] == pat(*Kanidm*)"


### PR DESCRIPTION
The auth-gate checks from #3642 were firing false `GatusAuthGateFailing` alerts for all 11 apps.

**Not fail-open** — verified the gates work (karma still `302 → idm`, all SecurityPolicies `Accepted=True`, secrets present). Gatus's actual error was `context deadline exceeded (Client.Timeout … awaiting headers)` on *every* check.

**Root cause:** I set `dns-resolver: tcp://192.168.1.200:53`, but the k8s-gateway DNS service listens on **UDP only** (`53:…/UDP`). The TCP DNS query hangs → the whole check times out → false "exposed" alert.

**Fix:** `udp://192.168.1.200:53`. Verified end-to-end from an in-cluster pod resolving via k8s-gateway: follow-redirect to the kanidm login page returns 200 with `Kanidm` in the body in ~15ms.

Once merged + reconciled, the 11 auth-gate checks go green and the alerts clear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)