### PR TITLE
fix(observability): disable postbuild substitution on bitmagnet dashboard

### DIFF
--- a/kubernetes/apps/main/downloads/bitmagnet/app/grafanadashboard.yaml
+++ b/kubernetes/apps/main/downloads/bitmagnet/app/grafanadashboard.yaml
@@ -4,6 +4,8 @@ apiVersion: grafana.integreatly.org/v1beta1
 kind: GrafanaDashboard
 metadata:
   name: bitmagnet
+  annotations:
+    kustomize.toolkit.fluxcd.io/substitute: disabled
 spec:
   allowCrossNamespaceImport: true
   instanceSelector:


### PR DESCRIPTION
## Context

Prep for the Flux distribution upgrade in #3551 (`2.8.8 → 2.9.1`).

kustomize-controller **v1.9.x enables `StrictPostBuildSubstitutions` by default** — reconciliation now fails when a manifest references an undefined `${VAR}` instead of leaving it as a literal string. Since `cluster-apps` (`kubernetes/clusters/main/ks.yaml`) patches `postBuild.substituteFrom: cluster-secrets` onto every child Kustomization, substitution scanning is active across the whole tree.

## The one genuinely affected resource

`bitmagnet/app/grafanadashboard.yaml` embeds an inline `json:` dashboard containing literal `${DS_PROMETHEUS}` / `${DS_LOKI}` grafana-operator datasource inputs. After the Flux 2.9 upgrade, strict mode would fail its reconciliation.

I audited all 17 `GrafanaDashboard` CRs flagged in the #3551 review — the other 16 are **not** affected:
- `url:` dashboards fetch JSON at runtime, so `${...}` never appears in the manifest Flux processes.
- `configMapRef:` dashboards whose JSON contains `${...}` (photon, nut-exporter) are already protected via `generatorOptions.annotations`.
- Bare `inputName: DS_PROMETHEUS` is a grafana-operator field, not Flux `${}` syntax.

## Fix

Add `kustomize.toolkit.fluxcd.io/substitute: disabled` to the bitmagnet dashboard so it is skipped during variable substitution — mirroring the protection already applied to ConfigMap-generated dashboards.

Should merge before #3551.

🤖 Generated with [Claude Code](https://claude.com/claude-code)