### PR TITLE
fix(flux): resolve strict postbuild substitution failures (komf, garage)

### DIFF
--- a/kubernetes/apps/main/media/komf/app/kustomization.yaml
+++ b/kubernetes/apps/main/media/komf/app/kustomization.yaml
@@ -13,3 +13,5 @@ configMapGenerator:
       - ./config/application.yml
 generatorOptions:
   disableNameSuffixHash: true
+  annotations:
+    kustomize.toolkit.fluxcd.io/substitute: disabled

--- a/kubernetes/apps/main/storage/garage/app/helmrelease.yaml
+++ b/kubernetes/apps/main/storage/garage/app/helmrelease.yaml
@@ -21,7 +21,7 @@ spec:
               repository: dxflrs/garage
               tag: v2.3.0@sha256:866bd13ed2038ba7e7190e840482bc27234c4afaf77be8cfa439ae088c1e4690
             env:
-              TZ: "${TIMEZONE}"
+              TZ: "Europe/Paris"
             envFrom:
               - secretRef:
                   name: garage-secret


### PR DESCRIPTION
## Problem

After the Flux distribution upgrade to **v2.9.1** (#3551) merged, kustomize-controller v1.9.x enabled `StrictPostBuildSubstitutions` by default. Two Kustomizations that previously reconciled (undefined `${VAR}` was silently left literal) now **fail reconciliation**:

```
media/komf     post build failed: variable not set (strict mode): "SECRET_KOMF_MAL_CLIENT_ID"
storage/garage post build failed: variable not set (strict mode): "TIMEZONE"
```

(The bitmagnet dashboard case was already handled in #3655.)

## Fixes

**komf** — `application.yml` has a *commented* example line referencing `${SECRET_KOMF_MAL_CLIENT_ID}`. That is komf's own runtime env-expansion syntax, not a Flux variable, but Flux's envsubst scans the raw ConfigMap string regardless of the YAML comment. Added `kustomize.toolkit.fluxcd.io/substitute: disabled` to the generated `komf-configmap` (the repo's established idiom for ConfigMap-generated content) so Flux leaves komf's `${...}` untouched. No other `${...}` in that config needs substitution.

**garage** — `TZ: "${TIMEZONE}"` referenced a variable that exists nowhere in `cluster-secrets`; it was silently left literal before strict mode (the running pod had no valid TZ). Hardcoded `TZ: "Europe/Paris"` to match the rest of the stack (n8n).

## Verification

- Confirmed via `kubectl get kustomization -A` that these are the **only** two Kustomizations failing on strict substitution cluster-wide.
- Confirmed `TIMEZONE` is absent from `cluster-secrets` and komf's config has no other substitution needs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)