### PR TITLE
feat(default): wire airtrail to kanidm oidc

### DIFF
--- a/kubernetes/apps/main/default/airtrail/app/helmrelease.yaml
+++ b/kubernetes/apps/main/default/airtrail/app/helmrelease.yaml
@@ -30,6 +30,18 @@ spec:
                   secretKeyRef:
                     name: postgres-airtrail-app
                     key: uri
+              # OIDC via Kanidm. openid-client v6 → PKCE + ES256 native, so the
+              # kanidm client keeps PKCE required and no legacy crypto. Auto-register
+              # creates SSO users as role=user; the first admin must still be a local
+              # account, and existing usernames must password-login once to link.
+              OAUTH_ENABLED: "true"
+              OAUTH_ISSUER_URL: "https://idm.${SECRET_DOMAIN}/oauth2/openid/airtrail/.well-known/openid-configuration"
+              OAUTH_SCOPE: "openid email profile"
+              OAUTH_BUTTON_TEXT: Log in with Kanidm
+            envFrom:
+              # OAUTH_CLIENT_ID / OAUTH_CLIENT_SECRET provisioned by kanidm-provision
+              - secretRef:
+                  name: kanidm-airtrail-oidc
             probes:
               liveness: &probes
                 enabled: true

--- a/kubernetes/apps/main/security/kanidm/app/provisioning/oauth2.yaml
+++ b/kubernetes/apps/main/security/kanidm/app/provisioning/oauth2.yaml
@@ -99,6 +99,18 @@ data:
             "clientSecretKey": "OAUTH_CLIENT_SECRET",
             "imageUrl": "https://raw.githubusercontent.com/homarr-labs/dashboard-icons/main/svg/karakeep.svg"
           }
+        },
+        "airtrail": {
+          "present": true, "displayName": "AirTrail",
+          "originUrl": "https://airtrail.${SECRET_DOMAIN}/login",
+          "originLanding": "https://airtrail.${SECRET_DOMAIN}/",
+          "scopeMaps": { "users": ["openid", "email", "profile"] },
+          "preferShortUsername": true,
+          "k8s": {
+            "clientIdKey": "OAUTH_CLIENT_ID",
+            "clientSecretKey": "OAUTH_CLIENT_SECRET",
+            "imageUrl": "https://raw.githubusercontent.com/homarr-labs/dashboard-icons/main/svg/airtrail.svg"
+          }
         }
       } } }
 ---


### PR DESCRIPTION
## What

Follow-up to #3661 (which merged the AirTrail app itself). Wires AirTrail to Kanidm OIDC.

- **Kanidm client** `airtrail` added to the `default`-namespace `kanidm-provision-oauth2-default` ConfigMap (next to karakeep). Redirect `https://airtrail.${SECRET_DOMAIN}/login`, `preferShortUsername: true`. Provisioner writes secret `kanidm-airtrail-oidc` with keys `OAUTH_CLIENT_ID` / `OAUTH_CLIENT_SECRET`.
- **HelmRelease** gains `OAUTH_ENABLED`, `OAUTH_ISSUER_URL` (Kanidm well-known), `OAUTH_SCOPE="openid email profile"`, button text, and `envFrom` the provisioned secret.

## Notes

- Unlike the Spring-based clients (Komga/Karakeep), AirTrail uses `openid-client` v6 which does **PKCE (S256) and ES256 natively** — so the client keeps **PKCE required** and skips `enableLegacyCrypto`.
- Auto-register creates SSO users as `role: user` only; the **first admin must be a local account**, and an existing local username must password-login once to link (AirTrail returns `oauth_link_required` rather than silently linking). `OAUTH_HIDE_PASSWORD_FORM` left at default `false` so that stays possible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)