### PR TITLE
chore(container): update image freikin/dawarich ( 1.9.2 → 1.10.0-rc.4 )

### DIFF
--- a/kubernetes/apps/main/default/dawarich/app/helmrelease.yaml
+++ b/kubernetes/apps/main/default/dawarich/app/helmrelease.yaml
@@ -18,7 +18,7 @@ spec:
           app: &dawarich
             image:
               repository: mirror.gcr.io/freikin/dawarich
-              tag: 1.9.2@sha256:c8413c39fd17bc801d9823507ae5ac08cf4333c6de5cd110922dbca31d097372
+              tag: 1.10.0-rc.4@sha256:6acb6635c0b196c9cd6c052d0061738950bf38e4f0b9a17d56edd6f144c98ce6
             env:
               TIME_ZONE: "Europe/Paris"
               PHOTON_API_HOST: photon.default.svc.cluster.local:2322


### PR DESCRIPTION
Manually bumps `freikin/dawarich` from `1.9.2` to the **release candidate** `1.10.0-rc.4`.

- Single edit at the container image tag; the worker container reuses it via the `&dawarich` YAML anchor, so both get the new version.
- Digest re-pinned to the multi-arch index: `sha256:6acb6635c0b196c9cd6c052d0061738950bf38e4f0b9a17d56edd6f144c98ce6`.

⚠️ This is a pre-release (rc), intentionally outside Renovate's stable-only automerge. Dawarich runs its own DB migrations on startup; keep an eye on the first rollout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)