### PR TITLE
revert(container): downgrade dawarich 1.10.0-rc.4 back to 1.9.2

### DIFF
--- a/kubernetes/apps/main/default/dawarich/app/helmrelease.yaml
+++ b/kubernetes/apps/main/default/dawarich/app/helmrelease.yaml
@@ -18,7 +18,7 @@ spec:
           app: &dawarich
             image:
               repository: mirror.gcr.io/freikin/dawarich
-              tag: 1.10.0-rc.4@sha256:6acb6635c0b196c9cd6c052d0061738950bf38e4f0b9a17d56edd6f144c98ce6
+              tag: 1.9.2@sha256:c8413c39fd17bc801d9823507ae5ac08cf4333c6de5cd110922dbca31d097372
             env:
               TIME_ZONE: "Europe/Paris"
               PHOTON_API_HOST: photon.default.svc.cluster.local:2322


### PR DESCRIPTION
## Summary
- 1.10.0-rc.4 turned out not to be what we wanted; reverting to the last stable release (1.9.2).
- Alongside this, the live `postgres-dawarich` CNPG cluster was already restored (via point-in-time recovery from the barman-cloud backup store) to 2026-07-10 15:20 UTC — just before the 1.10.0-rc.4 pod first booted — so the DB schema/data match the 1.9.2 era again. Verified against a throwaway parallel cluster before cutover (same migration count/version, matching row counts) then swapped in place.
- The app is currently running 1.9.2 directly via a manual kubectl patch (matching this commit) while the HelmRelease/Kustomization are suspended, to avoid Flux re-applying 1.10.0-rc.4 before this merges.

## Test plan
- [x] Restored cluster verified: 166/166 schema_migrations matching pre-1.10 state, point counts consistent
- [x] dawarich pod on 1.9.2 boots clean against restored DB, migrations run without error, `/api/v1/health` returns 200
- [ ] After merge: resume `kustomization/dawarich` and `helmrelease/dawarich` in the `default` namespace so GitOps state matches live state again

🤖 Generated with [Claude Code](https://claude.com/claude-code)