### PR TITLE
fix(container): update image mirror.gcr.io/freikin/dawarich ( 1.12.0 → 1.12.1 )

### DIFF
--- a/kubernetes/apps/main/default/dawarich/app/helmrelease.yaml
+++ b/kubernetes/apps/main/default/dawarich/app/helmrelease.yaml
@@ -18,7 +18,7 @@ spec:
           app: &dawarich
             image:
               repository: mirror.gcr.io/freikin/dawarich
-              tag: 1.12.0@sha256:e66b6742768d0b0d055f031bfc2c1fb87b45389f0564d6503cd654b18389aa0b
+              tag: 1.12.1@sha256:1b553dabfb7a689cc2b2fa15e22ac06a1ddaad104a82e693cbba6bb71ddb9d62
             env:
               TIME_ZONE: "Europe/Paris"
               PHOTON_API_HOST: photon.default.svc.cluster.local:2322


### PR DESCRIPTION
Manual bump ahead of Renovate's normal cycle — 1.12.1 is a hotfix for migration reliability on instances with a large number of visits (batched + resumable migrations), which matches this account's scale (5,800+ confirmed visits) and may explain why visit detection is currently returning zero results despite real point data.

Fixed (from upstream release notes):
- Migrations that could fail on self-hosted instances with a large number of visits now run in smaller batches and are resumable if interrupted.

Full changelog: https://github.com/Freika/dawarich/compare/1.12.0...1.12.1